### PR TITLE
Spill to dirty pages, write to disk

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,5 +1,7 @@
 package bolt
 
+const MaxBucketNameSize = 255
+
 type Bucket struct {
 	*bucket
 	name        string

--- a/leaf.go
+++ b/leaf.go
@@ -8,6 +8,7 @@ import (
 
 // leaf represents an in-memory, deserialized leaf page.
 type leaf struct {
+	pgid   pgid
 	parent *branch
 	items  leafItems
 }
@@ -39,10 +40,10 @@ func (l *leaf) put(key []byte, value []byte) {
 
 // read initializes the item data from an on-disk page.
 func (l *leaf) read(p *page) {
-	ncount := int(p.count)
-	l.items = make(leafItems, ncount)
+	l.pgid = p.id
+	l.items = make(leafItems, int(p.count))
 	lnodes := (*[maxNodesPerPage]lnode)(unsafe.Pointer(&p.ptr))
-	for i := 0; i < ncount; i++ {
+	for i := 0; i < int(p.count); i++ {
 		lnode := &lnodes[i]
 		item := &l.items[i]
 		item.key = lnode.key()

--- a/meta.go
+++ b/meta.go
@@ -14,8 +14,8 @@ type meta struct {
 	pageSize uint32
 	pgid     pgid
 	free     pgid
+	sys      pgid
 	txnid    txnid
-	sys      bucket
 }
 
 // validate checks the marker bytes and version of the meta page to ensure it matches this binary.
@@ -30,8 +30,20 @@ func (m *meta) validate() error {
 
 // copy copies one meta object to another.
 func (m *meta) copy(dest *meta) {
+	dest.magic = m.magic
+	dest.version = m.version
 	dest.pageSize = m.pageSize
 	dest.pgid = m.pgid
+	dest.free = m.free
 	dest.txnid = m.txnid
 	dest.sys = m.sys
+}
+
+// write writes the meta onto a page.
+func (m *meta) write(p *page) {
+	// Page id is either going to be 0 or 1 which we can determine by the Txn ID.
+	p.id = pgid(m.txnid % 2)
+	p.flags |= p_meta
+
+	m.copy(p.meta())
 }

--- a/page.go
+++ b/page.go
@@ -14,7 +14,8 @@ const (
 	p_branch   = 0x01
 	p_leaf     = 0x02
 	p_meta     = 0x04
-	p_freelist = 0x08
+	p_sys      = 0x08
+	p_freelist = 0x10
 )
 
 type pgid uint64
@@ -56,3 +57,9 @@ func (p *page) bnodes() []bnode {
 func (p *page) freelist() []pgid {
 	return ((*[maxNodesPerPage]pgid)(unsafe.Pointer(&p.ptr)))[0:p.count]
 }
+
+type pages []*page
+
+func (s pages) Len() int           { return len(s) }
+func (s pages) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s pages) Less(i, j int) bool { return s[i].id < s[j].id }

--- a/rwtransaction_test.go
+++ b/rwtransaction_test.go
@@ -27,18 +27,16 @@ func TestTransactionCreateBucket(t *testing.T) {
 		err = txn.Commit()
 		assert.NoError(t, err)
 
-		/*
-			// Open a separate read-only transaction.
-			rtxn, err := db.Transaction()
-			assert.NotNil(t, txn)
-			assert.NoError(t, err)
+		// Open a separate read-only transaction.
+		rtxn, err := db.Transaction()
+		assert.NotNil(t, txn)
+		assert.NoError(t, err)
 
-			b, err := rtxn.Bucket("widgets")
-			assert.NoError(t, err)
-			if assert.NotNil(t, b) {
-				assert.Equal(t, b.Name(), "widgets")
-			}
-		*/
+		b := rtxn.Bucket("widgets")
+		assert.NoError(t, err)
+		if assert.NotNil(t, b) {
+			assert.Equal(t, b.Name(), "widgets")
+		}
 	})
 }
 

--- a/sys.go
+++ b/sys.go
@@ -1,0 +1,95 @@
+package bolt
+
+import (
+	"sort"
+	"unsafe"
+)
+
+// sys represents a in-memory system page.
+type sys struct {
+	pgid    pgid
+	buckets map[string]*bucket
+}
+
+// size returns the size of the page after serialization.
+func (s *sys) size() int {
+	var size int = pageHeaderSize
+	for key, _ := range s.buckets {
+		size += int(unsafe.Sizeof(bucket{})) + len(key)
+	}
+	return size
+}
+
+// get retrieves a bucket by name.
+func (s *sys) get(key string) *bucket {
+	return s.buckets[key]
+}
+
+// put sets a new value for a bucket.
+func (s *sys) put(key string, b *bucket) {
+	s.buckets[key] = b
+}
+
+// del deletes a bucket by name.
+func (s *sys) del(key string) {
+	delete(s.buckets, key)
+}
+
+// read initializes the data from an on-disk page.
+func (s *sys) read(p *page) {
+	s.pgid = p.id
+	s.buckets = make(map[string]*bucket)
+
+	var buckets []*bucket
+	var keys []string
+
+	// Read buckets.
+	nodes := (*[maxNodesPerPage]bucket)(unsafe.Pointer(&p.ptr))
+	for i := 0; i < int(p.count); i++ {
+		node := &nodes[i]
+		buckets = append(buckets, node)
+	}
+
+	// Read keys.
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(&nodes[p.count]))[:]
+	for i := 0; i < int(p.count); i++ {
+		size := int(buf[0])
+		buf = buf[1:]
+		keys = append(keys, string(buf[:size]))
+		buf = buf[size:]
+	}
+
+	// Associate keys and buckets.
+	for index, key := range keys {
+		s.buckets[key] = buckets[index]
+	}
+}
+
+// write writes the items onto a page.
+func (s *sys) write(p *page) {
+	// Initialize page.
+	p.flags |= p_sys
+	p.count = uint16(len(s.buckets))
+
+	// Sort keys.
+	var keys []string
+	for key, _ := range s.buckets {
+		keys = append(keys, key)
+	}
+	sort.StringSlice(keys).Sort()
+
+	// Write each bucket to the page.
+	buckets := (*[maxNodesPerPage]bucket)(unsafe.Pointer(&p.ptr))
+	for index, key := range keys {
+		buckets[index] = *s.buckets[key]
+	}
+
+	// Write each key to the page.
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(&buckets[p.count]))[:]
+	for _, key := range keys {
+		buf[0] = byte(len(key))
+		buf = buf[1:]
+		copy(buf, []byte(key))
+		buf = buf[len(key):]
+	}
+}

--- a/sys_test.go
+++ b/sys_test.go
@@ -1,0 +1,70 @@
+package bolt
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure that a system page can set a bucket.
+func TestSysPut(t *testing.T) {
+	s := &sys{buckets: make(map[string]*bucket)}
+	s.put("foo", &bucket{root: 2})
+	s.put("bar", &bucket{root: 3})
+	s.put("foo", &bucket{root: 4})
+	assert.Equal(t, len(s.buckets), 2)
+	assert.Equal(t, s.get("foo").root, pgid(4))
+	assert.Equal(t, s.get("bar").root, pgid(3))
+	assert.Nil(t, s.get("no_such_bucket"))
+}
+
+// Ensure that a system page can deserialize from a page.
+func TestSysRead(t *testing.T) {
+	// Create a page.
+	var buf [4096]byte
+	page := (*page)(unsafe.Pointer(&buf[0]))
+	page.count = 2
+
+	// Insert 2 buckets at the beginning.
+	buckets := (*[3]bucket)(unsafe.Pointer(&page.ptr))
+	buckets[0] = bucket{root: 3}
+	buckets[1] = bucket{root: 4}
+
+	// Write data for the nodes at the end.
+	data := (*[4096]byte)(unsafe.Pointer(&buckets[2]))
+	data[0] = 3
+	copy(data[1:], []byte("bar"))
+	data[4] = 10
+	copy(data[5:], []byte("helloworld"))
+
+	// Deserialize page into a system page.
+	s := &sys{buckets: make(map[string]*bucket)}
+	s.read(page)
+
+	// Check that there are two items with correct data.
+	assert.Equal(t, len(s.buckets), 2)
+	assert.Equal(t, s.get("bar").root, pgid(3))
+	assert.Equal(t, s.get("helloworld").root, pgid(4))
+}
+
+// Ensure that a system page can serialize itself.
+func TestSysWrite(t *testing.T) {
+	s := &sys{buckets: make(map[string]*bucket)}
+	s.put("foo", &bucket{root: 2})
+	s.put("bar", &bucket{root: 3})
+
+	// Write it to a page.
+	var buf [4096]byte
+	p := (*page)(unsafe.Pointer(&buf[0]))
+	s.write(p)
+
+	// Read the page back in.
+	s2 := &sys{buckets: make(map[string]*bucket)}
+	s2.read(p)
+
+	// Check that the two pages are the same.
+	assert.Equal(t, len(s.buckets), 2)
+	assert.Equal(t, s.get("foo").root, pgid(2))
+	assert.Equal(t, s.get("bar").root, pgid(3))
+}

--- a/transaction.go
+++ b/transaction.go
@@ -1,9 +1,5 @@
 package bolt
 
-import (
-	"unsafe"
-)
-
 var (
 	InvalidTransactionError  = &Error{"txn is invalid", nil}
 	BucketAlreadyExistsError = &Error{"bucket already exists", nil}
@@ -19,22 +15,21 @@ const (
 type txnid uint64
 
 type Transaction struct {
-	id      int
-	db      *DB
-	meta    *meta
-	sys     Bucket
-	buckets map[string]*Bucket
-	pages   map[pgid]*page
+	id    int
+	db    *DB
+	meta  *meta
+	sys   *sys
+	pages map[pgid]*page
 }
 
 // init initializes the transaction and associates it with a database.
-func (t *Transaction) init(db *DB, meta *meta) {
+func (t *Transaction) init(db *DB) {
 	t.db = db
-	t.meta = meta
-	t.buckets = make(map[string]*Bucket)
+	t.meta = db.meta()
 	t.pages = nil
-	t.sys.transaction = t
-	t.sys.bucket = &t.meta.sys
+
+	t.sys = &sys{}
+	t.sys.read(t.page(t.meta.sys))
 }
 
 func (t *Transaction) Close() error {
@@ -48,26 +43,17 @@ func (t *Transaction) DB() *DB {
 
 // Bucket retrieves a bucket by name.
 func (t *Transaction) Bucket(name string) *Bucket {
-	// Return cached reference if it's already been looked up.
-	if b := t.buckets[name]; b != nil {
-		return b
-	}
-
-	// Retrieve bucket data from the system bucket.
-	value := t.sys.Cursor().Get([]byte(name))
-	if value == nil {
+	// Lookup bucket from the system page.
+	b := t.sys.get(name)
+	if b == nil {
 		return nil
 	}
 
-	// Create a bucket that overlays the data.
-	b := &Bucket{
-		bucket:      (*bucket)(unsafe.Pointer(&value[0])),
+	return &Bucket{
+		bucket:      b,
 		name:        name,
 		transaction: t,
 	}
-	t.buckets[name] = b
-
-	return b
 }
 
 // Cursor creates a cursor associated with a given bucket.


### PR DESCRIPTION
@snormore There's a bunch of changes in this PR but the biggest thing is that it'll actually create a bucket and read it back out in a separate transaction! Woohoo! Small victories. :)

I also simplified the bucket meta storage (called `sys` in the code). It was a real bucket that required a cursor to traverse but that was a pain in the ass. Most of the time there will be a relateivly small number of buckets so we don't need to optimize for a huge number by using a B+tree. There's now a page type called `p_sys` that just stores a list of buckets. Easy peasy. It's not very optimized right now but we can improve that later.

Next up is reading and writing data in a bucket. It's partially there but I need to test it and clean it up. Also, there's no support for spilling buckets to pages. I can explain everything in more detail tomorrow.
