### PR TITLE
Rebalance after deletion.

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // TODO(benbjohnson): Remove assertions before release.
 
-// __assert__ will panic with a given formatted message if the given condition is false.
-func __assert__(condition bool, msg string, v ...interface{}) {
+// _assert will panic with a given formatted message if the given condition is false.
+func _assert(condition bool, msg string, v ...interface{}) {
 	if !condition {
 		panic(fmt.Sprintf("assertion failed: " + msg, v...))
 	}

--- a/cursor.go
+++ b/cursor.go
@@ -115,12 +115,12 @@ func (c *Cursor) node(t *RWTransaction) *node {
 	// Start from root and traverse down the hierarchy.
 	n := t.node(c.stack[0].page.id, nil)
 	for _, ref := range c.stack[:len(c.stack)-1] {
-		__assert__(!n.isLeaf, "expected branch node")
-		__assert__(ref.page.id == n.pgid, "node/page mismatch a: %d != %d", ref.page.id, n.childAt(ref.index).pgid)
-		n = n.childAt(ref.index)
+		_assert(!n.isLeaf, "expected branch node")
+		_assert(ref.page.id == n.pgid, "node/page mismatch a: %d != %d", ref.page.id, n.childAt(int(ref.index)).pgid)
+		n = n.childAt(int(ref.index))
 	}
-	__assert__(n.isLeaf, "expected leaf node")
-	__assert__(n.pgid == c.stack[len(c.stack)-1].page.id, "node/page mismatch b: %d != %d", n.pgid, c.stack[len(c.stack)-1].page.id)
+	_assert(n.isLeaf, "expected leaf node")
+	_assert(n.pgid == c.stack[len(c.stack)-1].page.id, "node/page mismatch b: %d != %d", n.pgid, c.stack[len(c.stack)-1].page.id)
 	return n
 }
 

--- a/rwtransaction.go
+++ b/rwtransaction.go
@@ -99,9 +99,8 @@ func (t *RWTransaction) Delete(name string, key []byte) error {
 func (t *RWTransaction) Commit() error {
 	// TODO(benbjohnson): Use vectorized I/O to write out dirty pages.
 
-	// TODO: Rebalance.
-
-	// Spill data onto dirty pages.
+	// Rebalance and spill data onto dirty pages.
+	t.rebalance()
 	t.spill()
 
 	// Spill buckets page.
@@ -152,6 +151,13 @@ func (t *RWTransaction) allocate(count int) *page {
 	t.pages[p.id] = p
 
 	return p
+}
+
+// rebalance attempts to balance all nodes.
+func (t *RWTransaction) rebalance() {
+	for _, n := range t.nodes {
+		n.rebalance()
+	}
 }
 
 // spill writes all the nodes to dirty pages.


### PR DESCRIPTION
## Overview

Added rebalancing which will combine pages as needed after a key is removed. I also refactored the `node` type to allow sibling traversal.
## How it works

Rebalancing follows some fairly simple rules:
1. A node is a candidate for rebalancing if it is below a "fill threshold" (25%) or it doesn't have the minimum required number of keys (1 for leafs, 2 for branches).
2. If the node is the root node and it's a branch with only one key then collapse the child so it becomes the new root.
3. If the adjacent node has more than enough keys then just move one over.
4. If the adjacent node doesn't have more than the minimum number of keys then merge the two nodes. The reference to one of the nodes will be removed from the parent which will trigger a rebalance on that node.
## Caveats

Currently deletion seems to be dog slow. Not sure why yet but I haven't profiled it yet. Also, I added C-style assertion statements that I'm going to remove before the release. It just helps to track down dumb bugs during development.
