### PR TITLE
Remapping

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -187,6 +187,18 @@ func TestDBWriteFail(t *testing.T) {
 	t.Skip("pending") // TODO(benbjohnson)
 }
 
+// Ensure that the mmap grows appropriately.
+func TestDBMmapSize(t *testing.T) {
+	db := &DB{pageSize: 4096}
+	assert.Equal(t, db.mmapSize(0), minMmapSize)
+	assert.Equal(t, db.mmapSize(16384), minMmapSize)
+	assert.Equal(t, db.mmapSize(minMmapSize-1), minMmapSize)
+	assert.Equal(t, db.mmapSize(minMmapSize), minMmapSize*2)
+	assert.Equal(t, db.mmapSize(10000000), 20000768)
+	assert.Equal(t, db.mmapSize((1<<30)-1), 2147483648)
+	assert.Equal(t, db.mmapSize(1<<30), 1<<31)
+}
+
 // withDB executes a function with a database reference.
 func withDB(fn func(*DB, string)) {
 	f, _ := ioutil.TempFile("", "bolt-")

--- a/syscall_darwin.go
+++ b/syscall_darwin.go
@@ -6,11 +6,15 @@ import (
 
 type _syscall interface {
 	Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error)
+	Munmap([]byte) error
 }
 
 type syssyscall struct{}
 
 func (o *syssyscall) Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
-	// err = (EACCES, EBADF, EINVAL, ENODEV, ENOMEM, ENXIO, EOVERFLOW)
 	return syscall.Mmap(fd, offset, length, prot, flags)
+}
+
+func (o *syssyscall) Munmap(b []byte) error {
+	return syscall.Munmap(b)
 }

--- a/syscall_darwin_test.go
+++ b/syscall_darwin_test.go
@@ -12,3 +12,8 @@ func (m *mocksyscall) Mmap(fd int, offset int64, length int, prot int, flags int
 	args := m.Called(fd, offset, length, prot, flags)
 	return args.Get(0).([]byte), args.Error(1)
 }
+
+func (m *mocksyscall) Munmap(b []byte) error {
+	args := m.Called(b)
+	return args.Error(0)
+}

--- a/syscall_linux.go
+++ b/syscall_linux.go
@@ -6,6 +6,7 @@ import (
 
 type _syscall interface {
 	Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error)
+	Munmap([]byte) error
 }
 
 type syssyscall struct{}
@@ -13,4 +14,8 @@ type syssyscall struct{}
 func (o *syssyscall) Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
 	// err = (EACCES, EBADF, EINVAL, ENODEV, ENOMEM, ENXIO, EOVERFLOW)
 	return syscall.Mmap(fd, offset, length, prot, flags)
+}
+
+func (o *syssyscall) Munmap(b []byte) error {
+	return syscall.Munmap(b)
 }

--- a/syscall_linux_test.go
+++ b/syscall_linux_test.go
@@ -12,3 +12,8 @@ func (m *mocksyscall) Mmap(fd int, offset int64, length int, prot int, flags int
 	args := m.Called(fd, offset, length, prot, flags)
 	return args.Get(0).([]byte), args.Error(1)
 }
+
+func (m *mocksyscall) Munmap(b []byte) error {
+	args := m.Called(b)
+	return args.Error(0)
+}


### PR DESCRIPTION
## Overview

This pull request includes the ability to remap data files when allocating new pages from the end. This differs from LMDB's approach where there is a single fixed limit on the mmap size.
## Pros & Cons
### Contrasting with LMDB's Approach

LMDB's approach works well for the most part in that a user can simply set the mmap size to the size of the hard disk. One issue I ran into with this previously was that I was running many LMDB databases in the same process and setting a high limit for all of them which exhausted the virtual memory space for my process.
### Bolt's Approach

Bolt's approach is to start with a small memory mmap (4MB) and double it whenever the data file exceeds that size. The mmap uses a `sync.RWLock` so remapping can get exclusive access to the map. The downside of this is that it requires waiting for all read transactions to complete before remapping can occur. Bolt is aimed at short read transactions (because of its page reclamation design) so this shouldn't be an issue.
### Summary

I don't think either LMDB or Bolt has a better approach. I think they're just trade offs. Bolt's API aims to be simple and limit the number of configuration parameters but does it at some performance cost.

Feedback welcome.
