### PR TITLE
Transactional Blocks

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -178,6 +178,24 @@ func TestDBDelete(t *testing.T) {
 	})
 }
 
+// Ensure a database can provide a transactional block.
+func TestDBTransactionBlock(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		err := db.Do(func(txn *RWTransaction) error {
+			txn.CreateBucket("widgets")
+			txn.Put("widgets", []byte("foo"), []byte("bar"))
+			txn.Put("widgets", []byte("baz"), []byte("bat"))
+			txn.Delete("widgets", []byte("foo"))
+			return nil
+		})
+		assert.NoError(t, err)
+		value, _ := db.Get("widgets", []byte("foo"))
+		assert.Nil(t, value)
+		value, _ = db.Get("widgets", []byte("baz"))
+		assert.Equal(t, value, []byte("bat"))
+	})
+}
+
 // Ensure that the database can be copied to a writer.
 func TestDBCopy(t *testing.T) {
 	t.Skip("pending") // TODO(benbjohnson)

--- a/example_test.go
+++ b/example_test.go
@@ -60,6 +60,33 @@ func ExampleDB_Delete() {
 	// The value of 'foo' is now: nil
 }
 
+func ExampleDB_Do() {
+	// Open the database.
+	var db DB
+	db.Open("/tmp/bolt/db_do.db", 0666)
+	defer db.Close()
+
+	// Execute several commands within a write transaction.
+	err := db.Do(func(t *RWTransaction) error {
+		if err := t.CreateBucket("widgets"); err != nil {
+			return err
+		}
+		if err := t.Put("widgets", []byte("foo"), []byte("bar")); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// If our transactional block didn't return an error then our data is saved.
+	if err == nil {
+		value, _ := db.Get("widgets", []byte("foo"))
+		fmt.Printf("The value of 'foo' is: %s\n", string(value))
+	}
+
+	// Output:
+	// The value of 'foo' is: bar
+}
+
 func ExampleRWTransaction() {
 	// Open the database.
 	var db DB


### PR DESCRIPTION
## Overview

This pull request includes support for Transactional Blocks. This allows users to execute a transaction within a function without having to worry about deferring the commit/rollback. Any error returned from the function or that returns from the transaction's `Commit()` is returned from the block.

The transactional block is executed using the following method:

``` go
func (db *DB) Do(fn func(*RWTransaction) error) error
```

A read-only transactional block may be added in the future. Not sure what to call it yet.
## Example

``` go
func myFunc() error {
    ...

    // Execute several commands within a write transaction.
    err := db.Do(func(t *RWTransaction) error {
        if err := t.CreateBucket("widgets"); err != nil {
            return err
        }
        if err := t.Put("widgets", []byte("foo"), []byte("bar")); err != nil {
            return err
        }
        return nil
    })

    if err != nil {
        return err
    }

    ...
}
```

/cc @snormore
