### PR TITLE
ForEach()

### DIFF
--- a/db.go
+++ b/db.go
@@ -359,6 +359,17 @@ func (db *DB) Do(fn func(*RWTransaction) error) error {
 	return t.Commit()
 }
 
+// ForEach executes a function for each key/value pair in a bucket.
+// An error is returned if the bucket cannot be found.
+func (db *DB) ForEach(name string, fn func(k, v []byte) error) error {
+	t, err := db.Transaction()
+	if err != nil {
+		return err
+	}
+	defer t.Close()
+	return t.ForEach(name, fn)
+}
+
 // Bucket retrieves a reference to a bucket.
 // This is typically useful for checking the existence of a bucket.
 func (db *DB) Bucket(name string) (*Bucket, error) {

--- a/example_test.go
+++ b/example_test.go
@@ -87,6 +87,30 @@ func ExampleDB_Do() {
 	// The value of 'foo' is: bar
 }
 
+func ExampleDB_ForEach() {
+	// Open the database.
+	var db DB
+	db.Open("/tmp/bolt/db_foreach.db", 0666)
+	defer db.Close()
+
+	// Insert data into a bucket.
+	db.CreateBucket("animals")
+	db.Put("animals", []byte("dog"), []byte("fun"))
+	db.Put("animals", []byte("cat"), []byte("lame"))
+	db.Put("animals", []byte("liger"), []byte("awesome"))
+
+	// Iterate over items in sorted key order.
+	db.ForEach("animals", func(k, v []byte) error {
+		fmt.Printf("A %s is %s.\n", string(k), string(v))
+		return nil
+	})
+
+	// Output:
+	// A cat is lame.
+	// A dog is fun.
+	// A liger is awesome.
+}
+
 func ExampleRWTransaction() {
 	// Open the database.
 	var db DB

--- a/transaction.go
+++ b/transaction.go
@@ -93,6 +93,25 @@ func (t *Transaction) Get(name string, key []byte) (value []byte, err error) {
 	return c.Get(key), nil
 }
 
+// ForEach executes a function for each key/value pair in a bucket.
+// An error is returned if the bucket cannot be found.
+func (t *Transaction) ForEach(name string, fn func(k, v []byte) error) error {
+	// Open a cursor on the bucket.
+	c, err := t.Cursor(name)
+	if err != nil {
+		return err
+	}
+
+	// Iterate over each key/value pair in the bucket.
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // page returns a reference to the page with a given id.
 // If page has been written to then a temporary bufferred page is returned.
 func (t *Transaction) page(id pgid) *page {


### PR DESCRIPTION
## Overview

This pull request includes an ease-of-function on the `DB` and `Transaction` for iterating over a bucket.

```
func (db *DB) ForEach(name string, fn func(k, v []byte) error) error
func (t *Transaction) ForEach(name string, fn func(k, v []byte) error) error
```
## Usage

To iterate over all keys and values without worrying about opening and closing your `Transaction`, you can use `ForEach()`:

``` go
// Insert data into a bucket.
db.CreateBucket("animals")
db.Put("animals", []byte("dog"), []byte("fun"))
db.Put("animals", []byte("cat"), []byte("lame"))
db.Put("animals", []byte("liger"), []byte("awesome"))

// Iterate over items in sorted key order.
db.ForEach("animals", func(k, v []byte) error {
    fmt.Printf("A %s is %s.\n", string(k), string(v))
    return nil
})

// Output:
// A cat is lame.
// A dog is fun.
// A liger is awesome.
```

/cc @snormore
