### PR TITLE
Check for sequence overflow.

### DIFF
--- a/const.go
+++ b/const.go
@@ -3,6 +3,13 @@ package bolt
 const version = 1
 
 const (
+	maxUint = ^uint(0)
+	minUint = 0
+	maxInt  = int(^uint(0) >> 1)
+	minInt  = -maxInt - 1
+)
+
+const (
 	// MaxBucketNameSize is the maximum length of a bucket name, in bytes.
 	MaxBucketNameSize = 255
 

--- a/error.go
+++ b/error.go
@@ -38,6 +38,10 @@ var (
 
 	// ErrValueTooLarge is returned when inserting a value that is larger than MaxValueSize.
 	ErrValueTooLarge = &Error{"value too large", nil}
+
+	// ErrSequenceOverflow is returned when the next sequence number will be
+	// larger than the maximum integer size.
+	ErrSequenceOverflow = &Error{"sequence overflow", nil}
 )
 
 // Error represents an error condition caused by Bolt.

--- a/rwtransaction.go
+++ b/rwtransaction.go
@@ -82,6 +82,12 @@ func (t *RWTransaction) NextSequence(name string) (int, error) {
 		return 0, ErrBucketNotFound
 	}
 
+	// Make sure next sequence number will not be larger than the maximum
+	// integer size of the system.
+	if b.bucket.sequence == uint64(maxInt) {
+		return 0, ErrSequenceOverflow
+	}
+
 	// Increment and return the sequence.
 	b.bucket.sequence++
 

--- a/rwtransaction_test.go
+++ b/rwtransaction_test.go
@@ -136,6 +136,21 @@ func TestRWTransactionNextSequence(t *testing.T) {
 	})
 }
 
+// Ensure that incrementing past the maximum sequence number will return an error.
+func TestRWTransactionNextSequenceOverflow(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Do(func(txn *RWTransaction) error {
+			b := txn.Bucket("widgets")
+			b.bucket.sequence = uint64(maxInt)
+			seq, err := txn.NextSequence("widgets")
+			assert.Equal(t, err, ErrSequenceOverflow)
+			assert.Equal(t, seq, 0)
+			return nil
+		})
+	})
+}
+
 // Ensure that an error is returned when inserting into a bucket that doesn't exist.
 func TestRWTransactionPutBucketNotFound(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {


### PR DESCRIPTION
## Overview

This pull request adds a check that incrementing the next sequence won't overflow integers on the system and cause a panic. Instead a `ErrSequenceOverflow` error is returned.
