### PR TITLE
Refactor Bucket

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,13 +1,15 @@
 package bolt
 
+import (
+	"bytes"
+)
+
 // Bucket represents a collection of key/value pairs inside the database.
-// All keys inside the bucket are unique. The Bucket type is not typically used
-// directly. Instead the bucket name is typically passed into the Get(), Put(),
-// or Delete() functions.
 type Bucket struct {
 	*bucket
-	name        string
-	transaction *Transaction
+	name          string
+	transaction   *Transaction
+	rwtransaction *RWTransaction
 }
 
 // bucket represents the on-file representation of a bucket.
@@ -21,13 +23,108 @@ func (b *Bucket) Name() string {
 	return b.name
 }
 
-// cursor creates a new cursor for this bucket.
-func (b *Bucket) cursor() *Cursor {
+// Writable returns whether the bucket is writable.
+func (b *Bucket) Writable() bool {
+	return (b.rwtransaction != nil)
+}
+
+// Cursor creates a cursor associated with the bucket.
+// The cursor is only valid as long as the Transaction is open.
+// Do not use a cursor after the transaction is closed.
+func (b *Bucket) Cursor() *Cursor {
 	return &Cursor{
 		transaction: b.transaction,
 		root:        b.root,
 		stack:       make([]pageElementRef, 0),
 	}
+}
+
+// Get retrieves the value for a key in the bucket.
+// Returns a nil value if the key does not exist.
+func (b *Bucket) Get(key []byte) []byte {
+	c := b.Cursor()
+	k, v := c.Seek(key)
+
+	// If our target node isn't the same key as what's passed in then return nil.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+	return v
+}
+
+// Put sets the value for a key in the bucket.
+// If the key exist then its previous value will be overwritten.
+// Returns an error if the bucket was created from a read-only transaction, if the key is blank, if the key is too large, or if the value is too large.
+func (b *Bucket) Put(key []byte, value []byte) error {
+	if !b.Writable() {
+		return ErrBucketNotWritable
+	}
+
+	// Validate the key and data size.
+	if len(key) == 0 {
+		return ErrKeyRequired
+	} else if len(key) > MaxKeySize {
+		return ErrKeyTooLarge
+	} else if len(value) > MaxValueSize {
+		return ErrValueTooLarge
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	c.Seek(key)
+
+	// Insert the key/value.
+	c.node(b.rwtransaction).put(key, key, value, 0)
+
+	return nil
+}
+
+// Delete removes a key from the bucket.
+// If the key does not exist then nothing is done and a nil error is returned.
+// Returns an error if the bucket was created from a read-only transaction.
+func (b *Bucket) Delete(key []byte) error {
+	if !b.Writable() {
+		return ErrBucketNotWritable
+	}
+
+	// Move cursor to correct position.
+	c := b.Cursor()
+	c.Seek(key)
+
+	// Delete the node if we have a matching key.
+	c.node(b.rwtransaction).del(key)
+
+	return nil
+}
+
+// NextSequence returns an autoincrementing integer for the bucket.
+func (b *Bucket) NextSequence() (int, error) {
+	if !b.Writable() {
+		return 0, ErrBucketNotWritable
+	}
+
+	// Make sure next sequence number will not be larger than the maximum
+	// integer size of the system.
+	if b.bucket.sequence == uint64(maxInt) {
+		return 0, ErrSequenceOverflow
+	}
+
+	// Increment and return the sequence.
+	b.bucket.sequence++
+
+	return int(b.bucket.sequence), nil
+}
+
+// ForEach executes a function for each key/value pair in a bucket.
+// An error is returned if the bucket cannot be found.
+func (b *Bucket) ForEach(fn func(k, v []byte) error) error {
+	c := b.Cursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Stat returns stats on a bucket.

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1,12 +1,205 @@
 package bolt
 
 import (
+	"bytes"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// Ensure that a bucket that gets a non-existent key returns nil.
+func TestBucketGetNonExistent(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		value, err := db.Get("widgets", []byte("foo"))
+		if assert.NoError(t, err) {
+			assert.Nil(t, value)
+		}
+	})
+}
+
+// Ensure that a bucket can write a key/value.
+func TestBucketPut(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		err := db.Put("widgets", []byte("foo"), []byte("bar"))
+		assert.NoError(t, err)
+		value, err := db.Get("widgets", []byte("foo"))
+		if assert.NoError(t, err) {
+			assert.Equal(t, value, []byte("bar"))
+		}
+	})
+}
+
+// Ensure that setting a value on a read-only bucket returns an error.
+func TestBucketPutReadOnly(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.With(func(txn *Transaction) error {
+			b := txn.Bucket("widgets")
+			err := b.Put([]byte("foo"), []byte("bar"))
+			assert.Equal(t, err, ErrBucketNotWritable)
+			return nil
+		})
+	})
+}
+
+// Ensure that a bucket can delete an existing key.
+func TestBucketDelete(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Put("widgets", []byte("foo"), []byte("bar"))
+		err := db.Delete("widgets", []byte("foo"))
+		assert.NoError(t, err)
+		value, err := db.Get("widgets", []byte("foo"))
+		if assert.NoError(t, err) {
+			assert.Nil(t, value)
+		}
+	})
+}
+
+// Ensure that deleting a key on a read-only bucket returns an error.
+func TestBucketDeleteReadOnly(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.With(func(txn *Transaction) error {
+			b := txn.Bucket("widgets")
+			err := b.Delete([]byte("foo"))
+			assert.Equal(t, err, ErrBucketNotWritable)
+			return nil
+		})
+	})
+}
+
+// Ensure that a bucket can return an autoincrementing sequence.
+func TestBucketNextSequence(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.CreateBucket("woojits")
+
+		// Make sure sequence increments.
+		seq, err := db.NextSequence("widgets")
+		assert.NoError(t, err)
+		assert.Equal(t, seq, 1)
+		seq, err = db.NextSequence("widgets")
+		assert.NoError(t, err)
+		assert.Equal(t, seq, 2)
+
+		// Buckets should be separate.
+		seq, err = db.NextSequence("woojits")
+		assert.NoError(t, err)
+		assert.Equal(t, seq, 1)
+
+		// Missing buckets return an error.
+		seq, err = db.NextSequence("no_such_bucket")
+		assert.Equal(t, err, ErrBucketNotFound)
+		assert.Equal(t, seq, 0)
+	})
+}
+
+// Ensure that retrieving the next sequence on a read-only bucket returns an error.
+func TestBucketNextSequenceReadOnly(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.With(func(txn *Transaction) error {
+			b := txn.Bucket("widgets")
+			i, err := b.NextSequence()
+			assert.Equal(t, i, 0)
+			assert.Equal(t, err, ErrBucketNotWritable)
+			return nil
+		})
+	})
+}
+
+// Ensure that incrementing past the maximum sequence number will return an error.
+func TestBucketNextSequenceOverflow(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Do(func(txn *RWTransaction) error {
+			b := txn.Bucket("widgets")
+			b.bucket.sequence = uint64(maxInt)
+			seq, err := b.NextSequence()
+			assert.Equal(t, err, ErrSequenceOverflow)
+			assert.Equal(t, seq, 0)
+			return nil
+		})
+	})
+}
+
+// Ensure a database can loop over all key/value pairs in a bucket.
+func TestBucketForEach(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Put("widgets", []byte("foo"), []byte("0000"))
+		db.Put("widgets", []byte("baz"), []byte("0001"))
+		db.Put("widgets", []byte("bar"), []byte("0002"))
+
+		var index int
+		err := db.ForEach("widgets", func(k, v []byte) error {
+			switch index {
+			case 0:
+				assert.Equal(t, k, []byte("bar"))
+				assert.Equal(t, v, []byte("0002"))
+			case 1:
+				assert.Equal(t, k, []byte("baz"))
+				assert.Equal(t, v, []byte("0001"))
+			case 2:
+				assert.Equal(t, k, []byte("foo"))
+				assert.Equal(t, v, []byte("0000"))
+			}
+			index++
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, index, 3)
+	})
+}
+
+// Ensure a database can stop iteration early.
+func TestBucketForEachShortCircuit(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Put("widgets", []byte("bar"), []byte("0000"))
+		db.Put("widgets", []byte("baz"), []byte("0000"))
+		db.Put("widgets", []byte("foo"), []byte("0000"))
+
+		var index int
+		err := db.ForEach("widgets", func(k, v []byte) error {
+			index++
+			if bytes.Equal(k, []byte("baz")) {
+				return &Error{"marker", nil}
+			}
+			return nil
+		})
+		assert.Equal(t, err, &Error{"marker", nil})
+		assert.Equal(t, index, 2)
+	})
+}
+
+// Ensure that an error is returned when inserting with an empty key.
+func TestBucketPutEmptyKey(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		err := db.Put("widgets", []byte(""), []byte("bar"))
+		assert.Equal(t, err, ErrKeyRequired)
+		err = db.Put("widgets", nil, []byte("bar"))
+		assert.Equal(t, err, ErrKeyRequired)
+	})
+}
+
+// Ensure that an error is returned when inserting with a key that's too large.
+func TestBucketPutKeyTooLarge(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		err := db.Put("widgets", make([]byte, 32769), []byte("bar"))
+		assert.Equal(t, err, ErrKeyTooLarge)
+	})
+}
 
 // Ensure a bucket can calculate stats.
 func TestBucketStat(t *testing.T) {
@@ -14,20 +207,23 @@ func TestBucketStat(t *testing.T) {
 		db.Do(func(txn *RWTransaction) error {
 			// Add bucket with lots of keys.
 			txn.CreateBucket("widgets")
+			b := txn.Bucket("widgets")
 			for i := 0; i < 100000; i++ {
-				txn.Put("widgets", []byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
+				b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 			}
 
 			// Add bucket with fewer keys but one big value.
 			txn.CreateBucket("woojits")
+			b = txn.Bucket("woojits")
 			for i := 0; i < 500; i++ {
-				txn.Put("woojits", []byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
+				b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 			}
-			txn.Put("woojits", []byte("really-big-value"), []byte(strings.Repeat("*", 10000)))
+			b.Put([]byte("really-big-value"), []byte(strings.Repeat("*", 10000)))
 
 			// Add a bucket that fits on a single root leaf.
 			txn.CreateBucket("whozawhats")
-			txn.Put("whozawhats", []byte("foo"), []byte("bar"))
+			b = txn.Bucket("whozawhats")
+			b.Put([]byte("foo"), []byte("bar"))
 
 			return nil
 		})
@@ -59,4 +255,123 @@ func TestBucketStat(t *testing.T) {
 			return nil
 		})
 	})
+}
+
+// Ensure that a bucket can write random keys and values across multiple txns.
+func TestBucketPutSingle(t *testing.T) {
+	index := 0
+	f := func(items testdata) bool {
+		withOpenDB(func(db *DB, path string) {
+			m := make(map[string][]byte)
+
+			db.CreateBucket("widgets")
+			for _, item := range items {
+				if err := db.Put("widgets", item.Key, item.Value); err != nil {
+					panic("put error: " + err.Error())
+				}
+				m[string(item.Key)] = item.Value
+
+				// Verify all key/values so far.
+				i := 0
+				for k, v := range m {
+					value, err := db.Get("widgets", []byte(k))
+					if err != nil {
+						panic("get error: " + err.Error())
+					}
+					if !bytes.Equal(value, v) {
+						db.CopyFile("/tmp/bolt.put.single.db", 0666)
+						t.Fatalf("value mismatch [run %d] (%d of %d):\nkey: %x\ngot: %x\nexp: %x", index, i, len(m), []byte(k), value, v)
+					}
+					i++
+				}
+			}
+
+			fmt.Fprint(os.Stderr, ".")
+		})
+		index++
+		return true
+	}
+	if err := quick.Check(f, qconfig()); err != nil {
+		t.Error(err)
+	}
+	fmt.Fprint(os.Stderr, "\n")
+}
+
+// Ensure that a transaction can insert multiple key/value pairs at once.
+func TestBucketPutMultiple(t *testing.T) {
+	f := func(items testdata) bool {
+		withOpenDB(func(db *DB, path string) {
+			// Bulk insert all values.
+			db.CreateBucket("widgets")
+			rwtxn, _ := db.RWTransaction()
+			b := rwtxn.Bucket("widgets")
+			for _, item := range items {
+				assert.NoError(t, b.Put(item.Key, item.Value))
+			}
+			assert.NoError(t, rwtxn.Commit())
+
+			// Verify all items exist.
+			txn, _ := db.Transaction()
+			b = txn.Bucket("widgets")
+			for _, item := range items {
+				value := b.Get(item.Key)
+				if !assert.Equal(t, item.Value, value) {
+					db.CopyFile("/tmp/bolt.put.multiple.db", 0666)
+					t.FailNow()
+				}
+			}
+			txn.Close()
+		})
+		fmt.Fprint(os.Stderr, ".")
+		return true
+	}
+	if err := quick.Check(f, qconfig()); err != nil {
+		t.Error(err)
+	}
+	fmt.Fprint(os.Stderr, "\n")
+}
+
+// Ensure that a transaction can delete all key/value pairs and return to a single leaf page.
+func TestBucketDeleteQuick(t *testing.T) {
+	f := func(items testdata) bool {
+		withOpenDB(func(db *DB, path string) {
+			// Bulk insert all values.
+			db.CreateBucket("widgets")
+			rwtxn, _ := db.RWTransaction()
+			b := rwtxn.Bucket("widgets")
+			for _, item := range items {
+				assert.NoError(t, b.Put(item.Key, item.Value))
+			}
+			assert.NoError(t, rwtxn.Commit())
+
+			// Remove items one at a time and check consistency.
+			for i, item := range items {
+				assert.NoError(t, db.Delete("widgets", item.Key))
+
+				// Anything before our deletion index should be nil.
+				txn, _ := db.Transaction()
+				b := txn.Bucket("widgets")
+				for j, exp := range items {
+					if j > i {
+						value := b.Get(exp.Key)
+						if !assert.Equal(t, exp.Value, value) {
+							t.FailNow()
+						}
+					} else {
+						value := b.Get(exp.Key)
+						if !assert.Nil(t, value) {
+							t.FailNow()
+						}
+					}
+				}
+				txn.Close()
+			}
+		})
+		fmt.Fprint(os.Stderr, ".")
+		return true
+	}
+	if err := quick.Check(f, qconfig()); err != nil {
+		t.Error(err)
+	}
+	fmt.Fprint(os.Stderr, "\n")
 }

--- a/error.go
+++ b/error.go
@@ -30,6 +30,10 @@ var (
 	// that is longer than MaxBucketNameSize.
 	ErrBucketNameTooLarge = &Error{"bucket name too large", nil}
 
+	// ErrBucketNotWritable is returned when changing data on a bucket
+	// reference that was created from a read-only transaction.
+	ErrBucketNotWritable = &Error{"bucket not writable", nil}
+
 	// ErrKeyRequired is returned when inserting a zero-length key.
 	ErrKeyRequired = &Error{"key required", nil}
 

--- a/example_test.go
+++ b/example_test.go
@@ -71,7 +71,8 @@ func ExampleDB_Do() {
 		if err := t.CreateBucket("widgets"); err != nil {
 			return err
 		}
-		if err := t.Put("widgets", []byte("foo"), []byte("bar")); err != nil {
+		b := t.Bucket("widgets")
+		if err := b.Put([]byte("foo"), []byte("bar")); err != nil {
 			return err
 		}
 		return nil
@@ -100,7 +101,7 @@ func ExampleDB_With() {
 
 	// Access data from within a read-only transactional block.
 	db.With(func(t *Transaction) error {
-		v, _ := t.Get("people", []byte("john"))
+		v := t.Bucket("people").Get([]byte("john"))
 		fmt.Printf("John's last name is %s.\n", string(v))
 		return nil
 	})
@@ -144,14 +145,15 @@ func ExampleRWTransaction() {
 
 	// Create several keys in a transaction.
 	rwtxn, _ := db.RWTransaction()
-	rwtxn.Put("widgets", []byte("john"), []byte("blue"))
-	rwtxn.Put("widgets", []byte("abby"), []byte("red"))
-	rwtxn.Put("widgets", []byte("zephyr"), []byte("purple"))
+	b := rwtxn.Bucket("widgets")
+	b.Put([]byte("john"), []byte("blue"))
+	b.Put([]byte("abby"), []byte("red"))
+	b.Put([]byte("zephyr"), []byte("purple"))
 	rwtxn.Commit()
 
 	// Iterate over the values in sorted key order.
 	txn, _ := db.Transaction()
-	c, _ := txn.Cursor("widgets")
+	c := txn.Bucket("widgets").Cursor()
 	for k, v := c.First(); k != nil; k, v = c.Next() {
 		fmt.Printf("%s likes %s\n", string(k), string(v))
 	}
@@ -177,7 +179,8 @@ func ExampleRWTransaction_rollback() {
 
 	// Update the key but rollback the transaction so it never saves.
 	rwtxn, _ := db.RWTransaction()
-	rwtxn.Put("widgets", []byte("foo"), []byte("baz"))
+	b := rwtxn.Bucket("widgets")
+	b.Put([]byte("foo"), []byte("baz"))
 	rwtxn.Rollback()
 
 	// Ensure that our original value is still set.

--- a/functional_test.go
+++ b/functional_test.go
@@ -56,7 +56,7 @@ func TestParallelTransactions(t *testing.T) {
 
 						// Verify all data is in for local data list.
 						for _, item := range local {
-							value, err := txn.Get("widgets", item.Key)
+							value := txn.Bucket("widgets").Get(item.Key)
 							if !assert.NoError(t, err) || !assert.Equal(t, value, item.Value) {
 								txn.Close()
 								wg.Done()
@@ -89,8 +89,9 @@ func TestParallelTransactions(t *testing.T) {
 				}
 
 				// Insert whole batch.
+				b := txn.Bucket("widgets")
 				for _, item := range batchItems {
-					err := txn.Put("widgets", item.Key, item.Value)
+					err := b.Put(item.Key, item.Value)
 					if !assert.NoError(t, err) {
 						t.FailNow()
 					}


### PR DESCRIPTION
This pull request moves transaction functions to the Bucket itself. This is similar to pull request #50 but does not consolidate `Transaction` and `RWTransaction` together.

```
(b *Bucket) Cursor() *Cursor
(b *Bucket) Get(key []byte) []byte
(b *Bucket) Put(key []byte, value []byte) error
(b *Bucket) Delete(key []byte) error
(b *Bucket) NextSequence() (int, error)
(b *Bucket) ForEach(fn func(k, v []byte) error) error
```

Buckets created with a read-only transaction will return `ErrBucketNotWritable` when `Put()`, `Delete()`, and `NextSequence()` are called.

/cc @tv42
