### PR TITLE
Add bolt.Open()

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -1,0 +1,15 @@
+package bolt
+
+import (
+	"os"
+)
+
+// Open creates and opens a database at the given path.
+// If the file does not exist then it will be created automatically.
+func Open(path string, mode os.FileMode) (*DB, error) {
+	db := &DB{}
+	if err := db.Open(path, mode); err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/db_test.go
+++ b/db_test.go
@@ -15,6 +15,27 @@ import (
 )
 
 // Ensure that a database can be opened without error.
+func TestOpen(t *testing.T) {
+	f, _ := ioutil.TempFile("", "bolt-")
+	path := f.Name()
+	f.Close()
+	os.Remove(path)
+	defer os.RemoveAll(path)
+
+	db, err := Open(path, 0666)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+	db.Close()
+}
+
+// Ensure that opening a database with a bad path returns an error.
+func TestOpenBadPath(t *testing.T) {
+	db, err := Open("/../bad-path", 0666)
+	assert.Error(t, err)
+	assert.Nil(t, db)
+}
+
+// Ensure that a database can be opened without error.
 func TestDBOpen(t *testing.T) {
 	withDB(func(db *DB, path string) {
 		err := db.Open(path, 0666)


### PR DESCRIPTION
## Overview

Per the suggestion of @tv42 and @cespare, this commit adds a package-level function to create, initialize, and open a database at a given path.
## Example

```
db := bolt.Open("/my/db", 0600)
```
