### PR TITLE
Fix the mmap resize to use the correct size.

### DIFF
--- a/db.go
+++ b/db.go
@@ -146,7 +146,7 @@ func (db *DB) mmap(minsz int) error {
 	if size < minsz {
 		size = minsz
 	}
-	size = db.mmapSize(minsz)
+	size = db.mmapSize(size)
 
 	// Memory-map the data file as a byte slice.
 	if db.data, err = db.syscall.Mmap(int(db.file.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED); err != nil {


### PR DESCRIPTION
Previously the DB was calculating a minimum mmap size but using the wrong variable after it calculated the size. This commit changes the DB to use the correct variable.

Thanks to @cespare for catching the bug.

Fixes #54.
