### PR TITLE
Allow reads of unflushed nodes.

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -35,7 +35,7 @@ func (b *Bucket) Cursor() *Cursor {
 	return &Cursor{
 		transaction: b.transaction,
 		root:        b.root,
-		stack:       make([]pageElementRef, 0),
+		stack:       make([]elemRef, 0),
 	}
 }
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -23,6 +23,20 @@ func TestBucketGetNonExistent(t *testing.T) {
 	})
 }
 
+// Ensure that a bucket can read a value that is not flushed yet.
+func TestBucketGetFromNode(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.CreateBucket("widgets")
+		db.Do(func(txn *RWTransaction) error {
+			b := txn.Bucket("widgets")
+			b.Put([]byte("foo"), []byte("bar"))
+			value := b.Get([]byte("foo"))
+			assert.Equal(t, value, []byte("bar"))
+			return nil
+		})
+	})
+}
+
 // Ensure that a bucket can write a key/value.
 func TestBucketPut(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {

--- a/db.go
+++ b/db.go
@@ -304,7 +304,7 @@ func (db *DB) RWTransaction() (*RWTransaction, error) {
 	}
 
 	// Create a transaction associated with the database.
-	t := &RWTransaction{nodes: make(map[pgid]*node)}
+	t := &RWTransaction{}
 	t.init(db)
 	db.rwtransaction = t
 
@@ -571,7 +571,8 @@ func (db *DB) Stat() (*Stat, error) {
 
 // page retrieves a page reference from the mmap based on the current page size.
 func (db *DB) page(id pgid) *page {
-	return (*page)(unsafe.Pointer(&db.data[id*pgid(db.pageSize)]))
+	pos := id*pgid(db.pageSize)
+	return (*page)(unsafe.Pointer(&db.data[pos]))
 }
 
 // pageInBuffer retrieves a page reference from a given byte array based on the current page size.

--- a/page.go
+++ b/page.go
@@ -33,12 +33,6 @@ type page struct {
 	ptr      uintptr
 }
 
-// pageElementRef represents a reference to an element on a given page.
-type pageElementRef struct {
-	page  *page
-	index uint16
-}
-
 // typ returns a human readable page type string used for debugging.
 func (p *page) typ() string {
 	if (p.flags & branchPageFlag) != 0 {

--- a/rwtransaction.go
+++ b/rwtransaction.go
@@ -11,7 +11,6 @@ import (
 // functions provided by Transaction.
 type RWTransaction struct {
 	Transaction
-	nodes   map[pgid]*node
 	pending []*node
 }
 
@@ -20,6 +19,7 @@ func (t *RWTransaction) init(db *DB) {
 	t.Transaction.init(db)
 	t.Transaction.rwtransaction = t
 	t.pages = make(map[pgid]*page)
+	t.nodes = make(map[pgid]*node)
 
 	// Increment the transaction id.
 	t.meta.txnid += txnid(1)
@@ -266,7 +266,7 @@ func (t *RWTransaction) writeMeta() error {
 // node creates a node from a page and associates it with a given parent.
 func (t *RWTransaction) node(pgid pgid, parent *node) *node {
 	// Retrieve node if it has already been fetched.
-	if n := t.nodes[pgid]; n != nil {
+	if n := t.Transaction.node(pgid); n != nil {
 		return n
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -12,6 +12,7 @@ type Transaction struct {
 	rwtransaction *RWTransaction
 	meta          *meta
 	buckets       *buckets
+	nodes         map[pgid]*node
 	pages         map[pgid]*page
 }
 
@@ -93,6 +94,23 @@ func (t *Transaction) page(id pgid) *page {
 
 	// Otherwise return directly from the mmap.
 	return t.db.page(id)
+}
+
+// node returns a reference to the in-memory node for a given page, if it exists.
+func (t *Transaction) node(id pgid) *node {
+	if t.nodes == nil {
+		return nil
+	}
+	return t.nodes[id]
+}
+
+// pageNode returns the in-memory node, if it exists.
+// Otherwise returns the underlying page.
+func (t *Transaction) pageNode(id pgid) (*page, *node) {
+	if n := t.node(id); n != nil {
+		return nil, n
+	}
+	return t.page(id), nil
 }
 
 // forEachPage iterates over every page within a given page and executes a function.


### PR DESCRIPTION
This pull request allows cursors to read updated values from within the RWTransaction. Previously cursors would only read from pages (aka state of the data when the transaction started) but now they can work with nodes as well so they will see updates from within an RWTransaction before they are committed.

Before:

``` go
db.Do(func(txn *bolt.RWTransaction) error {
    b := txn.Bucket("widgets")
    b.Put([]byte("foo"), []byte("bar"))
    fmt.Println("The value of foo is: ", string(b.Get([]byte("foo"))))
    return nil
})

#=> The value of foo is: nil
```

Now it returns as you'd expect:

``` go
db.Do(func(txn *bolt.RWTransaction) error {
    b := txn.Bucket("widgets")
    b.Put([]byte("foo"), []byte("bar"))
    fmt.Println("The value of foo is: ", string(b.Get([]byte("foo"))))
    return nil
})

#=> The value of foo is: bar
```

This only affects reads inside of the RWTransaction. Read-only transactions will still consistently read from the pages.
