### PR TITLE
Fix Tx.Buckets() sort order.

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -154,3 +154,9 @@ type BucketStat struct {
 	KeyCount          int
 	MaxDepth          int
 }
+
+type bucketsByName []*Bucket
+
+func (s bucketsByName) Len() int           { return len(s) }
+func (s bucketsByName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s bucketsByName) Less(i, j int) bool { return s[i].name < s[j].name }

--- a/tx.go
+++ b/tx.go
@@ -89,6 +89,7 @@ func (t *Tx) Buckets() []*Bucket {
 		}
 		buckets = append(buckets, bucket)
 	}
+	sort.Sort(bucketsByName(buckets))
 	return buckets
 }
 


### PR DESCRIPTION
@tv42 reported an issue with bucket names returning incorrectly.

Fixes @62.
