### PR TITLE
Skip long-running tests with go test -short

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -217,6 +217,10 @@ func TestBucketPutKeyTooLarge(t *testing.T) {
 
 // Ensure a bucket can calculate stats.
 func TestBucketStat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	withOpenDB(func(db *DB, path string) {
 		db.Do(func(tx *Tx) error {
 			// Add bucket with lots of keys.
@@ -273,6 +277,10 @@ func TestBucketStat(t *testing.T) {
 
 // Ensure that a bucket can write random keys and values across multiple transactions.
 func TestBucketPutSingle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	index := 0
 	f := func(items testdata) bool {
 		withOpenDB(func(db *DB, path string) {
@@ -313,6 +321,10 @@ func TestBucketPutSingle(t *testing.T) {
 
 // Ensure that a transaction can insert multiple key/value pairs at once.
 func TestBucketPutMultiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	f := func(items testdata) bool {
 		withOpenDB(func(db *DB, path string) {
 			// Bulk insert all values.
@@ -347,6 +359,10 @@ func TestBucketPutMultiple(t *testing.T) {
 
 // Ensure that a transaction can delete all key/value pairs and return to a single leaf page.
 func TestBucketDeleteQuick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	f := func(items testdata) bool {
 		withOpenDB(func(db *DB, path string) {
 			// Bulk insert all values.

--- a/functional_test.go
+++ b/functional_test.go
@@ -13,6 +13,10 @@ import (
 
 // Ensure that multiple threads can use the DB without race detector errors.
 func TestParallelTxs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	var mutex sync.RWMutex
 
 	err := quick.Check(func(numReaders, batchSize uint, items testdata) bool {

--- a/tx_test.go
+++ b/tx_test.go
@@ -310,6 +310,10 @@ func TestTxCursorRestart(t *testing.T) {
 
 // Ensure that a Tx can iterate over all elements in a bucket.
 func TestTxCursorIterate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	f := func(items testdata) bool {
 		withOpenDB(func(db *DB, path string) {
 			// Bulk insert all values.
@@ -347,6 +351,10 @@ func TestTxCursorIterate(t *testing.T) {
 
 // Ensure that a transaction can iterate over all elements in a bucket in reverse.
 func TestTxCursorIterateReverse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	f := func(items testdata) bool {
 		withOpenDB(func(db *DB, path string) {
 			// Bulk insert all values.


### PR DESCRIPTION
"go test -short" only includes tests that run in under 3 seconds
