### PR TITLE
Fix 32bit build

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -64,7 +64,7 @@ func (b *Bucket) Put(key []byte, value []byte) error {
 		return ErrKeyRequired
 	} else if len(key) > MaxKeySize {
 		return ErrKeyTooLarge
-	} else if len(value) > MaxValueSize {
+	} else if int64(len(value)) > MaxValueSize {
 		return ErrValueTooLarge
 	}
 


### PR DESCRIPTION
Fix the error on 32bit machine: `bucket.go:67: constant 4294967295 overflows int`
