### PR TITLE
Mark Do()/With() transaction as managed.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -111,6 +111,23 @@ func TestDBTxBlockWhileClosed(t *testing.T) {
 	})
 }
 
+// Ensure a panic occurs while trying to commit a managed transaction.
+func TestDBTxBlockWithManualCommitAndRollback(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.Do(func(tx *Tx) error {
+			tx.CreateBucket("widgets")
+			assert.Panics(t, func() { tx.Commit() })
+			assert.Panics(t, func() { tx.Rollback() })
+			return nil
+		})
+		db.With(func(tx *Tx) error {
+			assert.Panics(t, func() { tx.Commit() })
+			assert.Panics(t, func() { tx.Rollback() })
+			return nil
+		})
+	})
+}
+
 // Ensure that the database can be copied to a file path.
 func TestDBCopyFile(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {

--- a/tx.go
+++ b/tx.go
@@ -18,6 +18,7 @@ type txid uint64
 // quickly grow.
 type Tx struct {
 	writable bool
+	managed  bool
 	db       *DB
 	meta     *meta
 	buckets  *buckets
@@ -155,7 +156,9 @@ func (t *Tx) DeleteBucket(name string) error {
 // Commit writes all changes to disk and updates the meta page.
 // Returns an error if a disk write error occurs.
 func (t *Tx) Commit() error {
-	if t.db == nil {
+	if t.managed {
+		panic("managed tx commit not allowed")
+	} else if t.db == nil {
 		return nil
 	} else if !t.writable {
 		t.Rollback()
@@ -194,6 +197,9 @@ func (t *Tx) Commit() error {
 
 // Rollback closes the transaction and ignores all previous updates.
 func (t *Tx) Rollback() {
+	if t.managed {
+		panic("managed tx rollback not allowed")
+	}
 	t.close()
 }
 


### PR DESCRIPTION
Transaction created from Do() and With() are now considered "managed". Managed transactions cannot be manually committed or rolled back since the Do() and With() functions provide that functionally automatically. Previously, a Tx could be manually committed and then any changes after that would be lost.

Managed transactions will now panic if they are manually committed or rolled back. A `panic()` is used because there is no recovery option and the end user should be notified that they are using the `Tx` incorrectly -- even if they are not checking their return errors.

---

Related: https://github.com/boltdb/bolt/issues/72#issuecomment-38341639 by @tv42:

> As for the example at the end, I firmly believe Commit/Rollback belongs in the With/Do level, I'm not suggesting a change there. But as it is now, _the inner function can call Commit/Rollback, and the result can be confusing_. That's what the example tried to demonstrate. In the example, the changes are committed to the db, but the caller sees an error. Imagine that Commit being somewhere a few levels deeper, and it can get messy to debug. I don't immediately see a use case for the inner function being able to call Commit/Rollback.

---
