### PR TITLE
Add ErrTxClosed error.

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -16,6 +16,7 @@ type Cursor struct {
 // First moves the cursor to the first item in the bucket and returns its key and value.
 // If the bucket is empty then a nil key and value are returned.
 func (c *Cursor) First() (key []byte, value []byte) {
+	_assert(c.tx.db != nil, "tx closed")
 	c.stack = c.stack[:0]
 	p, n := c.tx.pageNode(c.root)
 	c.stack = append(c.stack, elemRef{page: p, node: n, index: 0})
@@ -26,6 +27,7 @@ func (c *Cursor) First() (key []byte, value []byte) {
 // Last moves the cursor to the last item in the bucket and returns its key and value.
 // If the bucket is empty then a nil key and value are returned.
 func (c *Cursor) Last() (key []byte, value []byte) {
+	_assert(c.tx.db != nil, "tx closed")
 	c.stack = c.stack[:0]
 	p, n := c.tx.pageNode(c.root)
 	ref := elemRef{page: p, node: n}
@@ -38,6 +40,8 @@ func (c *Cursor) Last() (key []byte, value []byte) {
 // Next moves the cursor to the next item in the bucket and returns its key and value.
 // If the cursor is at the end of the bucket then a nil key and value are returned.
 func (c *Cursor) Next() (key []byte, value []byte) {
+	_assert(c.tx.db != nil, "tx closed")
+
 	// Attempt to move over one element until we're successful.
 	// Move up the stack as we hit the end of each page in our stack.
 	for i := len(c.stack) - 1; i >= 0; i-- {
@@ -62,6 +66,8 @@ func (c *Cursor) Next() (key []byte, value []byte) {
 // Prev moves the cursor to the previous item in the bucket and returns its key and value.
 // If the cursor is at the beginning of the bucket then a nil key and value are returned.
 func (c *Cursor) Prev() (key []byte, value []byte) {
+	_assert(c.tx.db != nil, "tx closed")
+
 	// Attempt to move back one element until we're successful.
 	// Move up the stack as we hit the beginning of each page in our stack.
 	for i := len(c.stack) - 1; i >= 0; i-- {
@@ -87,6 +93,8 @@ func (c *Cursor) Prev() (key []byte, value []byte) {
 // If the key does not exist then the next key is used. If no keys
 // follow, a nil value is returned.
 func (c *Cursor) Seek(seek []byte) (key []byte, value []byte) {
+	_assert(c.tx.db != nil, "tx closed")
+
 	// Start from root page/node and traverse to correct page.
 	c.stack = c.stack[:0]
 	c.search(seek, c.root)

--- a/error.go
+++ b/error.go
@@ -20,6 +20,10 @@ var (
 	// read-only transaction.
 	ErrTxNotWritable = &Error{"tx not writable", nil}
 
+	// ErrTxClosed is returned when committing or rolling back a transaction
+	// that has already been committed or rolled back.
+	ErrTxClosed = &Error{"tx closed", nil}
+
 	// ErrBucketNotFound is returned when trying to access a bucket that has
 	// not been created yet.
 	ErrBucketNotFound = &Error{"bucket not found", nil}

--- a/tx_test.go
+++ b/tx_test.go
@@ -13,6 +13,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure that committing a closed transaction returns an error.
+func TestTxCommitClosed(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		tx, _ := db.RWTx()
+		tx.CreateBucket("foo")
+		assert.NoError(t, tx.Commit())
+		assert.Equal(t, tx.Commit(), ErrTxClosed)
+	})
+}
+
+// Ensure that rolling back a closed transaction returns an error.
+func TestTxRollbackClosed(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		tx, _ := db.RWTx()
+		assert.NoError(t, tx.Rollback())
+		assert.Equal(t, tx.Rollback(), ErrTxClosed)
+	})
+}
+
+// Ensure that committing a read-only transaction returns an error.
+func TestTxCommitReadOnly(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		tx, _ := db.Tx()
+		assert.Equal(t, tx.Commit(), ErrTxNotWritable)
+	})
+}
+
 // Ensure that the database can retrieve a list of buckets.
 func TestTxBuckets(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {
@@ -38,6 +65,15 @@ func TestTxCreateBucketReadOnly(t *testing.T) {
 			assert.Equal(t, tx.CreateBucket("foo"), ErrTxNotWritable)
 			return nil
 		})
+	})
+}
+
+// Ensure that creating a bucket on a closed transaction returns an error.
+func TestTxCreateBucketClosed(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		tx, _ := db.RWTx()
+		tx.Commit()
+		assert.Equal(t, tx.CreateBucket("foo"), ErrTxClosed)
 	})
 }
 
@@ -201,6 +237,15 @@ func TestTxDeleteBucket(t *testing.T) {
 			assert.Nil(t, tx.Bucket("widgets").Get([]byte("foo")))
 			return nil
 		})
+	})
+}
+
+// Ensure that deleting a bucket on a closed transaction returns an error.
+func TestTxDeleteBucketClosed(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		tx, _ := db.RWTx()
+		tx.Commit()
+		assert.Equal(t, tx.DeleteBucket("foo"), ErrTxClosed)
 	})
 }
 


### PR DESCRIPTION
Commit/Rollback and mutable calls on Tx and Bucket now return ErrTxClosed if the transaction has already been committed or rolled back. Non-mutable calls have added an assertion to check if the transaction is closed which will cause a panic. I don't want to introduce an error return for accessor methods that are being used improperly so I think the panic is appropriate.

This PR also changes `Commit()` so that it returns `ErrTxNotWritable` if called on a read-only `Tx`.

Fixes: #73

/cc @tv42
