### PR TITLE
Make DB/Tx API more consistent.

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -66,7 +66,7 @@ func GetCommand(c *cli.Context) {
 	}
 	defer db.Close()
 
-	err = db.With(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		// Find bucket.
 		b := tx.Bucket(name)
 		if b == nil {
@@ -105,7 +105,7 @@ func SetCommand(c *cli.Context) {
 	}
 	defer db.Close()
 
-	err = db.Do(func(tx *bolt.Tx) error {
+	err = db.Update(func(tx *bolt.Tx) error {
 		// Find bucket.
 		b := tx.Bucket(name)
 		if b == nil {
@@ -137,7 +137,7 @@ func KeysCommand(c *cli.Context) {
 	}
 	defer db.Close()
 
-	err = db.With(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		// Find bucket.
 		b := tx.Bucket(name)
 		if b == nil {
@@ -172,7 +172,7 @@ func BucketsCommand(c *cli.Context) {
 	}
 	defer db.Close()
 
-	err = db.With(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		for _, b := range tx.Buckets() {
 			println(b.Name())
 		}
@@ -202,7 +202,7 @@ func PagesCommand(c *cli.Context) {
 	println("ID       TYPE       ITEMS  OVRFLW")
 	println("======== ========== ====== ======")
 
-	db.Do(func(tx *bolt.Tx) error {
+	db.Update(func(tx *bolt.Tx) error {
 		var id int
 		for {
 			p, err := tx.Page(id)

--- a/cmd/bolt/main_test.go
+++ b/cmd/bolt/main_test.go
@@ -15,7 +15,7 @@ import (
 func TestGet(t *testing.T) {
 	SetTestMode(true)
 	open(func(db *bolt.DB) {
-		db.Do(func(tx *bolt.Tx) error {
+		db.Update(func(tx *bolt.Tx) error {
 			tx.CreateBucket("widgets")
 			tx.Bucket("widgets").Put([]byte("foo"), []byte("bar"))
 			return nil
@@ -45,7 +45,7 @@ func TestGetBucketNotFound(t *testing.T) {
 func TestGetKeyNotFound(t *testing.T) {
 	SetTestMode(true)
 	open(func(db *bolt.DB) {
-		db.Do(func(tx *bolt.Tx) error {
+		db.Update(func(tx *bolt.Tx) error {
 			return tx.CreateBucket("widgets")
 		})
 		output := run("get", db.Path(), "widgets", "foo")
@@ -57,7 +57,7 @@ func TestGetKeyNotFound(t *testing.T) {
 func TestSet(t *testing.T) {
 	SetTestMode(true)
 	open(func(db *bolt.DB) {
-		db.Do(func(tx *bolt.Tx) error {
+		db.Update(func(tx *bolt.Tx) error {
 			tx.CreateBucket("widgets")
 			return nil
 		})
@@ -86,7 +86,7 @@ func TestSetBucketNotFound(t *testing.T) {
 func TestKeys(t *testing.T) {
 	SetTestMode(true)
 	open(func(db *bolt.DB) {
-		db.Do(func(tx *bolt.Tx) error {
+		db.Update(func(tx *bolt.Tx) error {
 			tx.CreateBucket("widgets")
 			tx.Bucket("widgets").Put([]byte("0002"), []byte(""))
 			tx.Bucket("widgets").Put([]byte("0001"), []byte(""))
@@ -118,7 +118,7 @@ func TestKeysBucketNotFound(t *testing.T) {
 func TestBuckets(t *testing.T) {
 	SetTestMode(true)
 	open(func(db *bolt.DB) {
-		db.Do(func(tx *bolt.Tx) error {
+		db.Update(func(tx *bolt.Tx) error {
 			tx.CreateBucket("woojits")
 			tx.CreateBucket("widgets")
 			tx.CreateBucket("whatchits")

--- a/functional_test.go
+++ b/functional_test.go
@@ -28,7 +28,7 @@ func TestParallelTxs(t *testing.T) {
 		var current testdata
 
 		withOpenDB(func(db *DB, path string) {
-			db.Do(func(tx *Tx) error {
+			db.Update(func(tx *Tx) error {
 				return tx.CreateBucket("widgets")
 			})
 
@@ -51,7 +51,7 @@ func TestParallelTxs(t *testing.T) {
 					go func() {
 						mutex.RLock()
 						local := current
-						tx, err := db.Tx()
+						tx, err := db.Begin(false)
 						mutex.RUnlock()
 						if err == ErrDatabaseNotOpen {
 							wg.Done()
@@ -89,7 +89,7 @@ func TestParallelTxs(t *testing.T) {
 				pending = pending[currentBatchSize:]
 
 				// Start write transaction.
-				tx, err := db.RWTx()
+				tx, err := db.Begin(true)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}


### PR DESCRIPTION
I consolidated the DB.Tx() and DB.RWTx() calls into a single DB.Begin(writable bool) call. This is more consistent with the database/sql library.

I also changed the DB.Do() and DB.With() call to DB.Update() and DB.View(), respectively. This is more intuitive and more inline with other database verbiage.

Fixes #72.
