### PR TITLE
Fix bucket reclamation

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -195,13 +195,14 @@ func (t *Tx) Commit() error {
 	}
 	t.buckets.write(p)
 
+	// Free previous bucket page and update meta.
+	t.db.freelist.free(t.id(), t.page(t.meta.buckets))
+	t.meta.buckets = p.id
+
 	// Write dirty pages to disk.
 	if err := t.write(); err != nil {
 		return err
 	}
-
-	// Update the meta.
-	t.meta.buckets = p.id
 
 	// Write meta to disk.
 	if err := t.writeMeta(); err != nil {

--- a/tx_test.go
+++ b/tx_test.go
@@ -230,7 +230,7 @@ func TestTxDeleteBucket(t *testing.T) {
 
 		db.Update(func(tx *Tx) error {
 			// Verify that the bucket's page is free.
-			assert.Equal(t, []pgid{root}, db.freelist.all())
+			assert.Equal(t, []pgid{6, root, 3}, db.freelist.all())
 
 			// Create the bucket again and make sure there's not a phantom value.
 			assert.NoError(t, tx.CreateBucket("widgets"))


### PR DESCRIPTION
The bucket page is allocated separately from the rest of the pages but the old bucket pages were not being added to the freelist. This change fixes that and adds a simple check for database consistency. More advanced consistency checks can be added in the future.

Fixes #82.
Fixes #89.
