### PR TITLE
Add DB.Check().

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -15,6 +15,14 @@ func Open(path string, mode os.FileMode) (*DB, error) {
 	return db, nil
 }
 
+// ErrorList represents a slice of errors.
+type ErrorList []error
+
+// Error returns a readable count of the errors in the list.
+func (l ErrorList) Error() string {
+	return fmt.Sprintf("%d errors occurred", len(l))
+}
+
 // _assert will panic with a given formatted message if the given condition is false.
 func _assert(condition bool, msg string, v ...interface{}) {
 	if !condition {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -271,6 +271,7 @@ func TestBucketStat(t *testing.T) {
 
 			return nil
 		})
+		mustCheck(db)
 		db.View(func(tx *Tx) error {
 			b := tx.Bucket("widgets")
 			stat := b.Stat()

--- a/cmd/bolt/check.go
+++ b/cmd/bolt/check.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+
+	"github.com/boltdb/bolt"
+)
+
+// Check performs a consistency check on the database and prints any errors found.
+func Check(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fatal(err)
+		return
+	}
+
+	db, err := bolt.Open(path, 0600)
+	if err != nil {
+		fatal(err)
+		return
+	}
+	defer db.Close()
+
+	// Perform consistency check.
+	if err := db.Check(); err != nil {
+		if errors, ok := err.(bolt.ErrorList); ok {
+			for _, err := range errors {
+				println(err)
+			}
+		}
+		fatalln(err)
+		return
+	}
+	println("OK")
+}

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -61,6 +61,14 @@ func NewApp() *cli.App {
 				Pages(path)
 			},
 		},
+		{
+			Name:  "check",
+			Usage: "Performs a consistency check on the database",
+			Action: func(c *cli.Context) {
+				path := c.Args().Get(0)
+				Check(path)
+			},
+		},
 	}
 	return app
 }


### PR DESCRIPTION
> Work-in-progress

This pull request adds a consistency check to `DB` and `bolt fsck` to the CLI.

It currently implements the following checks:
- Check that all reachable pages are branches or leafs.
- Check that all pages below the high water mark are either reachable or in the freelist.

I still need to add more checks but this uncovered an issue in `TestBucketDeleteQuick` that I still need to resolve.

Fixes: #96

/cc @pkieltyka @tv42
