### PR TITLE
Write freelist after each commit.

### DIFF
--- a/cmd/bolt/pages.go
+++ b/cmd/bolt/pages.go
@@ -39,7 +39,10 @@ func Pages(path string) {
 				overflow = strconv.Itoa(p.OverflowCount)
 			}
 			printf("%-8d %-10s %-6d %-6s\n", p.ID, p.Type, p.Count, overflow)
-			id += 1 + p.OverflowCount
+			id += 1
+			if p.Type != "free" {
+				id += p.OverflowCount
+			}
 		}
 		return nil
 	})

--- a/freelist.go
+++ b/freelist.go
@@ -12,6 +12,11 @@ type freelist struct {
 	pending map[txid][]pgid
 }
 
+// size returns the size of the page after serialization.
+func (f *freelist) size() int {
+	return pageHeaderSize + (int(unsafe.Sizeof(pgid(0))) * len(f.all()))
+}
+
 // all returns a list of all free ids and all pending ids in one sorted list.
 func (f *freelist) all() []pgid {
 	ids := make([]pgid, len(f.ids))

--- a/tx_test.go
+++ b/tx_test.go
@@ -230,7 +230,7 @@ func TestTxDeleteBucket(t *testing.T) {
 
 		db.Update(func(tx *Tx) error {
 			// Verify that the bucket's page is free.
-			assert.Equal(t, []pgid{6, root, 3}, db.freelist.all())
+			assert.Equal(t, []pgid{7, 6, root, 2}, db.freelist.all())
 
 			// Create the bucket again and make sure there's not a phantom value.
 			assert.NoError(t, tx.CreateBucket("widgets"))


### PR DESCRIPTION
Well, this is embarrassing. Somehow the freelist was never getting written after each commit. This commit fixes that and fixes a small reporting issue with "bolt pages".

This pull request is brought to you by don't-trust-your-test-coverage-numbers-alone. :)

Thanks to @tv42 and @pkieltyka for their help in figuring this out.

Fixes: #100
