### PR TITLE
Consolidate file and metafile descriptors.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -381,7 +381,10 @@ func (t *Tx) writeMeta() error {
 	t.meta.write(p)
 
 	// Write the meta page to file.
-	if _, err := t.db.ops.metaWriteAt(buf, int64(p.id)*int64(t.db.pageSize)); err != nil {
+	if _, err := t.db.ops.writeAt(buf, int64(p.id)*int64(t.db.pageSize)); err != nil {
+		return err
+	}
+	if err := fdatasync(t.db.file); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously, a two file descriptors were used for the database: file & metafile. The "file" file descriptor was used for async writes while the "metafile" file descriptor was used with O_SYNC writes. This commit changes that so that there's only one file descriptor and it uses fdatasync() to synchronize writes.

Fixes #106.

/cc @tv42
