### PR TITLE
Rename internal local Tx variables.

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -259,7 +259,7 @@ func (c *Cursor) keyValue() ([]byte, []byte) {
 }
 
 // node returns the node that the cursor is currently positioned on.
-func (c *Cursor) node(t *Tx) *node {
+func (c *Cursor) node(tx *Tx) *node {
 	_assert(len(c.stack) > 0, "accessing a node with a zero-length cursor stack")
 
 	// If the top of the stack is a leaf node then just return it.
@@ -270,7 +270,7 @@ func (c *Cursor) node(t *Tx) *node {
 	// Start from root and traverse down the hierarchy.
 	var n = c.stack[0].node
 	if n == nil {
-		n = t.node(c.stack[0].page.id, nil)
+		n = tx.node(c.stack[0].page.id, nil)
 	}
 	for _, ref := range c.stack[:len(c.stack)-1] {
 		_assert(!n.isLeaf, "expected branch node")

--- a/db.go
+++ b/db.go
@@ -361,7 +361,7 @@ func (db *DB) beginRWTx() (*Tx, error) {
 }
 
 // removeTx removes a transaction from the database.
-func (db *DB) removeTx(t *Tx) {
+func (db *DB) removeTx(tx *Tx) {
 	db.metalock.Lock()
 	defer db.metalock.Unlock()
 
@@ -369,15 +369,15 @@ func (db *DB) removeTx(t *Tx) {
 	db.mmaplock.RUnlock()
 
 	// Remove the transaction.
-	for i, tx := range db.txs {
-		if tx == t {
+	for i, t := range db.txs {
+		if t == tx {
 			db.txs = append(db.txs[:i], db.txs[i+1:]...)
 			break
 		}
 	}
 
 	// Merge statistics.
-	db.stats.TxStats.add(&t.stats)
+	db.stats.TxStats.add(&tx.stats)
 }
 
 // Update executes a function within the context of a read-write managed transaction.

--- a/example_test.go
+++ b/example_test.go
@@ -54,8 +54,8 @@ func ExampleDB_View() {
 	})
 
 	// Access data from within a read-only transactional block.
-	db.View(func(t *Tx) error {
-		v := t.Bucket("people").Get([]byte("john"))
+	db.View(func(tx *Tx) error {
+		v := tx.Bucket("people").Get([]byte("john"))
 		fmt.Printf("John's last name is %s.\n", string(v))
 		return nil
 	})


### PR DESCRIPTION
This commit changes the local Tx variables from "t" to "tx". This is partly for consistency with external documentation but also because it just annoys me for some reason.

There's no functional change with this pull request -- just a lot more X's.
