### PR TITLE
Add Cursor.Bucket() function.

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -12,6 +12,11 @@ type Cursor struct {
 	stack  []elemRef
 }
 
+// Bucket returns the bucket that this cursor was created from.
+func (c *Cursor) Bucket() *Bucket {
+	return c.bucket
+}
+
 // First moves the cursor to the first item in the bucket and returns its key and value.
 // If the bucket is empty then a nil key and value are returned.
 func (c *Cursor) First() (key []byte, value []byte) {

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Ensure that a cursor can return a reference to the bucket that created it.
+func TestCursor_Bucket(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.Update(func(tx *Tx) error {
+			b, _ := tx.CreateBucket([]byte("widgets"))
+			c := b.Cursor()
+			assert.Equal(t, b, c.Bucket())
+			return nil
+		})
+	})
+}
+
 // Ensure that a Tx cursor can seek to the appropriate keys.
 func TestCursor_Seek(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {


### PR DESCRIPTION
This commit adds an accessor to the Cursor type to retrieve the Bucket that it was created from.

/cc @mkobetic
