### PR TITLE
More C cursor improvements

### DIFF
--- a/c/cursor.go
+++ b/c/cursor.go
@@ -337,9 +337,7 @@ func (c *Cursor) First() (key, value []byte) {
 	var k, v C.bolt_val
 	var flags C.uint32_t
 	C.bolt_cursor_first(c.C, &k, &v, &flags)
-	fmt.Printf("key: %#v, value: %#v\n", k, v)
-	fmt.Printf("k.data: %#v, k.size: %#v\n", uintptr(k.data), int(k.size))
-	if uintptr(k.data) == uintptr(0) {
+	if k.data == nil {
 		return nil, nil
 	}
 	return C.GoBytes(k.data, C.int(k.size)), C.GoBytes(v.data, C.int(v.size))
@@ -351,8 +349,7 @@ func (c *Cursor) Next() (key, value []byte) {
 	var k, v C.bolt_val
 	var flags C.uint32_t
 	C.bolt_cursor_next(c.C, &k, &v, &flags)
-	fmt.Printf("key: %#v, value: %#v\n", k, v)
-	if k.size == 0 {
+	if k.data == nil {
 		return nil, nil
 	}
 	return C.GoBytes(k.data, C.int(k.size)), C.GoBytes(v.data, C.int(v.size))
@@ -369,13 +366,9 @@ func (c *Cursor) Seek(seek []byte) (key, value []byte, flags int) {
 		_seek.data = unsafe.Pointer(&seek[0])
 	}
 	C.bolt_cursor_seek(c.C, _seek, &k, &v, &_flags)
-	fmt.Printf("Key %#v [%#v]\n", k.data, k.size)
-	fmt.Printf("Value %#v [%#v]\n", k.data, k.size)
-	fmt.Printf("key: %#v, value: %#v\n", k, v)
-	if k.size == 0 {
+	if k.data == nil {
 		return nil, nil, 0
 	}
-
 	return C.GoBytes(k.data, C.int(k.size)), C.GoBytes(v.data, C.int(v.size)), int(_flags)
 }
 

--- a/c/cursor_test.go
+++ b/c/cursor_test.go
@@ -38,14 +38,14 @@ func TestCursor_Empty(t *testing.T) {
 		db.View(func(tx *bolt.Tx) error {
 			c := NewCursor(tx.Bucket([]byte("widgets")))
 			key, value := c.First()
-			assert.Equal(t, nil, key)
-			assert.Equal(t, nil, value)
+			assert.Nil(t, key)
+			assert.Nil(t, value)
 			key, value = c.Next()
-			assert.Equal(t, nil, key)
-			assert.Equal(t, nil, value)
+			assert.Nil(t, key)
+			assert.Nil(t, value)
 			key, value, flags := c.Seek([]byte("bar"))
-			assert.Equal(t, nil, key)
-			assert.Equal(t, nil, value)
+			assert.Nil(t, key)
+			assert.Nil(t, value)
 			assert.Equal(t, 0, flags)
 			return nil
 		})
@@ -204,7 +204,7 @@ func TestCursor_Iterate_Deep(t *testing.T) {
 			}
 			assert.Equal(t, 1000, index)
 			k, _ := c.Next()
-			assert.Equal(t, nil, k)
+			assert.Nil(t, k)
 			return nil
 		})
 	})


### PR DESCRIPTION
- fixes 2 problems with the seek implementation
- adds tests for all that
- cleans up the C code some more
- makes sure that cursor at end (including cursor on empty bucket) always returns NULL key and value
- comment cleanup

@benbjohnson 
/cc @Shopify/reports 
