### PR TITLE
Allow calling b.Bucket(x) when b == nil

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -94,7 +94,12 @@ func (b *Bucket) Cursor() *Cursor {
 
 // Bucket retrieves a nested bucket by name.
 // Returns nil if the bucket does not exist.
+// Returns nil if called on a nil bucket.
 func (b *Bucket) Bucket(name []byte) *Bucket {
+	if b == nil {
+		return nil
+	}
+
 	if child := b.buckets[string(name)]; child != nil {
 		return child
 	}

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -25,6 +25,18 @@ func TestBucket_Get_NonExistent(t *testing.T) {
 	})
 }
 
+// Ensure that you can call Bucket on a nil bucket without panic
+func TestBucket_Get_Nil(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.Update(func(tx *Tx) error {
+			tx.CreateBucket([]byte("widgets"))
+			value := tx.Bucket([]byte("widgets")).Bucket([]byte("sub")).Bucket([]byte("more"))
+			assert.Nil(t, value)
+			return nil
+		})
+	})
+}
+
 // Ensure that a bucket can read a value that is not flushed yet.
 func TestBucket_Get_FromNode(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {


### PR DESCRIPTION
This is useful when opening nested buckets, allowing you to check for
non-existence only once at the end.
