### PR TITLE
Printf's %s and %q already do the right thing with []byte

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -745,7 +745,7 @@ func ExampleBucket_Put() {
 	// Read value back in a different read-only transaction.
 	db.Update(func(tx *Tx) error {
 		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
-		fmt.Printf("The value of 'foo' is: %s\n", string(value))
+		fmt.Printf("The value of 'foo' is: %s\n", value)
 		return nil
 	})
 
@@ -770,7 +770,7 @@ func ExampleBucket_Delete() {
 
 		// Retrieve the key back from the database and verify it.
 		value := b.Get([]byte("foo"))
-		fmt.Printf("The value of 'foo' was: %s\n", string(value))
+		fmt.Printf("The value of 'foo' was: %s\n", value)
 		return nil
 	})
 
@@ -809,7 +809,7 @@ func ExampleBucket_ForEach() {
 
 		// Iterate over items in sorted key order.
 		b.ForEach(func(k, v []byte) error {
-			fmt.Printf("A %s is %s.\n", string(k), string(v))
+			fmt.Printf("A %s is %s.\n", k, v)
 			return nil
 		})
 		return nil

--- a/db_test.go
+++ b/db_test.go
@@ -375,7 +375,7 @@ func ExampleDB_Update() {
 	if err == nil {
 		db.View(func(tx *Tx) error {
 			value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
-			fmt.Printf("The value of 'foo' is: %s\n", string(value))
+			fmt.Printf("The value of 'foo' is: %s\n", value)
 			return nil
 		})
 	}
@@ -402,7 +402,7 @@ func ExampleDB_View() {
 	// Access data from within a read-only transactional block.
 	db.View(func(tx *Tx) error {
 		v := tx.Bucket([]byte("people")).Get([]byte("john"))
-		fmt.Printf("John's last name is %s.\n", string(v))
+		fmt.Printf("John's last name is %s.\n", v)
 		return nil
 	})
 
@@ -434,7 +434,7 @@ func ExampleDB_Begin_ReadOnly() {
 	tx, _ = db.Begin(false)
 	c := tx.Bucket([]byte("widgets")).Cursor()
 	for k, v := c.First(); k != nil; k, v = c.Next() {
-		fmt.Printf("%s likes %s\n", string(k), string(v))
+		fmt.Printf("%s likes %s\n", k, v)
 	}
 	tx.Rollback()
 
@@ -469,7 +469,7 @@ func ExampleDB_CopyFile() {
 	// Ensure that the key exists in the copy.
 	db2.View(func(tx *Tx) error {
 		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
-		fmt.Printf("The value for 'foo' in the clone is: %s\n", string(value))
+		fmt.Printf("The value for 'foo' in the clone is: %s\n", value)
 		return nil
 	})
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -289,7 +289,7 @@ func ExampleTx_Rollback() {
 	// Ensure that our original value is still set.
 	db.View(func(tx *Tx) error {
 		value := tx.Bucket([]byte("widgets")).Get([]byte("foo"))
-		fmt.Printf("The value for 'foo' is still: %s\n", string(value))
+		fmt.Printf("The value for 'foo' is still: %s\n", value)
 		return nil
 	})
 


### PR DESCRIPTION
Converting []byte -> string for use with fmt.Printf's %s and/or %q is unnecessary. This simplifies many of the Examples.
