### PR TITLE
Add Tx.Cursor().

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -75,6 +75,14 @@ func (tx *Tx) Writable() bool {
 	return tx.writable
 }
 
+// Cursor creates a cursor associated with the root bucket.
+// All items in the cursor will return a nil value because all root bucket keys point to buckets.
+// The cursor is only valid as long as the transaction is open.
+// Do not use a cursor after the transaction is closed.
+func (tx *Tx) Cursor() *Cursor {
+	return tx.root.Cursor()
+}
+
 // Stats retrieves a copy of the current transaction statistics.
 func (tx *Tx) Stats() TxStats {
 	return tx.stats

--- a/tx_test.go
+++ b/tx_test.go
@@ -36,6 +36,31 @@ func TestTx_Commit_ReadOnly(t *testing.T) {
 	})
 }
 
+// Ensure that a transaction can retrieve a cursor on the root bucket.
+func TestTx_Cursor(t *testing.T) {
+	withOpenDB(func(db *DB, path string) {
+		db.Update(func(tx *Tx) error {
+			tx.CreateBucket([]byte("widgets"))
+			tx.CreateBucket([]byte("woojits"))
+			c := tx.Cursor()
+
+			k, v := c.First()
+			assert.Equal(t, "widgets", string(k))
+			assert.Nil(t, v)
+
+			k, v = c.Next()
+			assert.Equal(t, "woojits", string(k))
+			assert.Nil(t, v)
+
+			k, v = c.Next()
+			assert.Nil(t, k)
+			assert.Nil(t, v)
+
+			return nil
+		})
+	})
+}
+
 // Ensure that creating a bucket with a read-only transaction returns an error.
 func TestTx_CreateBucket_ReadOnly(t *testing.T) {
 	withOpenDB(func(db *DB, path string) {


### PR DESCRIPTION
This commit adds the Cursor() function to Tx. This allows iteration on the root bucket in a similar way to iteration on other buckets.

Note: This does expose the root bucket via `tx.Cursor().Bucket()`. I'm not sure I want to add code to prevent `Put()` against the root bucket in such a round-about way.

Fixes #141.

---

/cc @tv42
