### PR TITLE
Add streaming stats to bolt bench.

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/codegangsta/cli"
 )
@@ -104,19 +105,26 @@ func NewApp() *cli.App {
 				&cli.StringFlag{Name: "cpuprofile", Usage: "CPU profile output path"},
 				&cli.StringFlag{Name: "memprofile", Usage: "Memory profile output path"},
 				&cli.StringFlag{Name: "blockprofile", Usage: "Block profile output path"},
+				&cli.StringFlag{Name: "stats-interval", Value: "0s", Usage: "Continuous stats interval"},
 			},
 			Action: func(c *cli.Context) {
+				statsInterval, err := time.ParseDuration(c.String("stats-interval"))
+				if err != nil {
+					fatal(err)
+				}
+
 				Bench(&BenchOptions{
-					ProfileMode:  c.String("profile-mode"),
-					WriteMode:    c.String("write-mode"),
-					ReadMode:     c.String("read-mode"),
-					Iterations:   c.Int("count"),
-					BatchSize:    c.Int("batch-size"),
-					KeySize:      c.Int("key-size"),
-					ValueSize:    c.Int("value-size"),
-					CPUProfile:   c.String("cpuprofile"),
-					MemProfile:   c.String("memprofile"),
-					BlockProfile: c.String("blockprofile"),
+					ProfileMode:   c.String("profile-mode"),
+					WriteMode:     c.String("write-mode"),
+					ReadMode:      c.String("read-mode"),
+					Iterations:    c.Int("count"),
+					BatchSize:     c.Int("batch-size"),
+					KeySize:       c.Int("key-size"),
+					ValueSize:     c.Int("value-size"),
+					CPUProfile:    c.String("cpuprofile"),
+					MemProfile:    c.String("memprofile"),
+					BlockProfile:  c.String("blockprofile"),
+					StatsInterval: statsInterval,
 				})
 			},
 		}}


### PR DESCRIPTION
This commit adds -stats-interval to the 'bolt bench' utility. By setting this argument to an interval greater than `0s`, the benchmark tool will output stats as streaming JSON. This data can, in turn, be graphed to understand performance over time.

Note: This field is simply parsed by [`time.ParseDuration()`](http://golang.org/pkg/time/#ParseDuration) so see that function's format for more details.

Note: The final timings are now printed to `stderr` so that the `stdout` can be output cleanly and consumed by another charting application.

/cc @snormore @mkobetic
