### PR TITLE
Add 'bolt info'.

### DIFF
--- a/cmd/bolt/info.go
+++ b/cmd/bolt/info.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	"github.com/boltdb/bolt"
+)
+
+// Info prints basic information about a database.
+func Info(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fatal(err)
+		return
+	}
+
+	db, err := bolt.Open(path, 0600)
+	if err != nil {
+		fatal(err)
+		return
+	}
+	defer db.Close()
+
+	// Print basic database info.
+	var info = db.Info()
+	printf("Page Size: %d", info.PageSize)
+}

--- a/cmd/bolt/info_test.go
+++ b/cmd/bolt/info_test.go
@@ -1,0 +1,32 @@
+package main_test
+
+import (
+	"testing"
+
+	"github.com/boltdb/bolt"
+	. "github.com/boltdb/bolt/cmd/bolt"
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure that a database info can be printed.
+func TestInfo(t *testing.T) {
+	SetTestMode(true)
+	open(func(db *bolt.DB, path string) {
+		db.Update(func(tx *bolt.Tx) error {
+			tx.CreateBucket([]byte("widgets"))
+			b := tx.Bucket([]byte("widgets"))
+			b.Put([]byte("foo"), []byte("0000"))
+			return nil
+		})
+		db.Close()
+		output := run("info", path)
+		assert.Equal(t, `Page Size: 4096`, output)
+	})
+}
+
+// Ensure that an error is reported if the database is not found.
+func TestInfo_NotFound(t *testing.T) {
+	SetTestMode(true)
+	output := run("info", "no/such/db")
+	assert.Equal(t, "stat no/such/db: no such file or directory", output)
+}

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -26,6 +26,14 @@ func NewApp() *cli.App {
 	app.Version = fmt.Sprintf("0.1.0 (%s %s)", branch, commit)
 	app.Commands = []cli.Command{
 		{
+			Name:  "info",
+			Usage: "Print basic information about a database",
+			Action: func(c *cli.Context) {
+				path := c.Args().Get(0)
+				Info(path)
+			},
+		},
+		{
 			Name:  "get",
 			Usage: "Retrieve a value for given key in a bucket",
 			Action: func(c *cli.Context) {


### PR DESCRIPTION
This pull request simply adds `bolt info` to the CLI. Currently it just prints page size but other basic info will probably be added in the future (e.g. tree depth, etc).
