### PR TITLE
Add -work flag to 'bolt bench'.

### DIFF
--- a/cmd/bolt/bench.go
+++ b/cmd/bolt/bench.go
@@ -33,7 +33,12 @@ func Bench(options *BenchOptions) {
 
 	// Find temporary location.
 	path := tempfile()
-	defer os.Remove(path)
+
+	if options.Clean {
+		defer os.Remove(path)
+	} else {
+		println("work:", path)
+	}
 
 	// Create database.
 	db, err := bolt.Open(path, 0600)
@@ -275,6 +280,7 @@ type BenchOptions struct {
 	MemProfile    string
 	BlockProfile  string
 	StatsInterval time.Duration
+	Clean         bool
 }
 
 // BenchResults represents the performance results of the benchmark.

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -106,6 +106,7 @@ func NewApp() *cli.App {
 				&cli.StringFlag{Name: "memprofile", Usage: "Memory profile output path"},
 				&cli.StringFlag{Name: "blockprofile", Usage: "Block profile output path"},
 				&cli.StringFlag{Name: "stats-interval", Value: "0s", Usage: "Continuous stats interval"},
+				&cli.BoolFlag{Name: "work", Usage: "Print the temp db and do not delete on exit"},
 			},
 			Action: func(c *cli.Context) {
 				statsInterval, err := time.ParseDuration(c.String("stats-interval"))
@@ -125,6 +126,7 @@ func NewApp() *cli.App {
 					MemProfile:    c.String("memprofile"),
 					BlockProfile:  c.String("blockprofile"),
 					StatsInterval: statsInterval,
+					Clean:         !c.Bool("work"),
 				})
 			},
 		}}


### PR DESCRIPTION
### Overview

This commit adds a 'work' flag to the bolt bench utility so that databases generated by the bench CLI can be saved for analysis.
### Example

``` sh
$ bolt bench -work
work: /var/folders/p3/nqt2bgp17fn7_t9hr6tr_1m00000gn/T/bolt-bench-624397481
# Write 1.917837341s    (1.917837ms/op) (521 op/sec)
# Read  1.000024224s    (32ns/op)   (31250000 op/sec)

$ bolt check /var/folders/p3/nqt2bgp17fn7_t9hr6tr_1m00000gn/T/bolt-bench-624397481
OK
```
