### PR TITLE
Add strict mode.

### DIFF
--- a/tx_test.go
+++ b/tx_test.go
@@ -288,6 +288,31 @@ func TestTx_OnCommit_Rollback(t *testing.T) {
 	assert.Equal(t, 0, x)
 }
 
+// Ensure that a Tx in strict mode will fail when corrupted.
+func TestTx_Check_Corrupt(t *testing.T) {
+	var msg string
+	func() {
+		defer func() {
+			msg = fmt.Sprintf("%s", recover())
+		}()
+
+		withOpenDB(func(db *DB, path string) {
+			db.StrictMode = true
+			db.Update(func(tx *Tx) error {
+				tx.CreateBucket([]byte("foo"))
+
+				// Corrupt the DB by adding a page to the freelist.
+				warn("---")
+				db.freelist.free(0, tx.page(3))
+
+				return nil
+			})
+		})
+	}()
+
+	assert.Equal(t, "check fail: 1 errors occurred: page 3: already freed", msg)
+}
+
 func ExampleTx_Rollback() {
 	// Open the database.
 	db, _ := Open(tempfile(), 0666)


### PR DESCRIPTION
This pull request adds a `StrictMode` option as it's described in #164. The following changes were made to support this:
- The `Check()` implementation has been moved to `Tx`. It is still callable from `DB.Check()`.
- Added a check for pages that are double freed: `already freed`
- Added check for for pages that are reachable but are also on the freelist: `reachable freed`

I'll add line notes for clarity.

---

Fixes #164.

/cc @snormore @mkobetic @pkieltyka
