### PR TITLE
Remove allocations from read-only buckets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ BRANCH=`git rev-parse --abbrev-ref HEAD`
 COMMIT=`git rev-parse --short HEAD`
 GOLDFLAGS="-X main.branch $(BRANCH) -X main.commit $(COMMIT)"
 
+default: build
+
 bench:
 	go test -v -test.run=NOTHINCONTAINSTHIS -test.bench=$(BENCH)
 


### PR DESCRIPTION
## Overview

Subbuckets are currently being tracked and cached by the parent bucket using a map. However, this is only necessary for write transactions since they need to be able to track dirty subbuckets. This caching causes the bucket and the map to be created on the heap which kills performance when performing iteration over a large number of subbuckets.
## Changes

This pull request makes two changes:
- Remove unnecessary bucket-related allocations on read-only transactions.
- Add `seq-nest` and `rnd-nest` write modes for `bolt bench`.

See line notes below for additional details.

/cc @snomore @mkobetic
