### PR TITLE
Avoid trashing page cache on Tx.Copy().

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -2,7 +2,11 @@
 
 package bolt
 
-import "os"
+import (
+	"os"
+)
+
+var odirect int
 
 func fdatasync(f *os.File) error {
 	return f.Sync()

--- a/bolt_linux.go
+++ b/bolt_linux.go
@@ -5,6 +5,8 @@ import (
 	"syscall"
 )
 
+var odirect = syscall.O_DIRECT
+
 func fdatasync(f *os.File) error {
 	return syscall.Fdatasync(int(f.Fd()))
 }

--- a/tx.go
+++ b/tx.go
@@ -240,7 +240,7 @@ func (tx *Tx) close() {
 // Copy will write exactly tx.Size() bytes into the writer.
 func (tx *Tx) Copy(w io.Writer) error {
 	// Open reader on the database.
-	f, err := os.Open(tx.db.path)
+	f, err := os.OpenFile(tx.db.path, os.O_RDONLY|odirect, 0)
 	if err != nil {
 		_ = tx.Rollback()
 		return err


### PR DESCRIPTION
This commit change the database copy to use O_DIRECT so that the Linux page cache is not trashed during a backup. This is only available on Linux.

*Note: The `odirect` name is used instead of `o_direct` to avoid golint warnings.

/cc @snormore @mkobetic
