### PR TITLE
Remove DB.Check(). Allow read-only Tx.Check().

### DIFF
--- a/cmd/bolt/check.go
+++ b/cmd/bolt/check.go
@@ -21,7 +21,12 @@ func Check(path string) {
 	defer db.Close()
 
 	// Perform consistency check.
-	if err := db.Check(); err != nil {
+	err = db.View(func(tx *bolt.Tx) error {
+		return tx.Check()
+	})
+
+	// Print out any errors that occur.
+	if err != nil {
 		if errors, ok := err.(bolt.ErrorList); ok {
 			for _, err := range errors {
 				println(err)

--- a/db.go
+++ b/db.go
@@ -501,14 +501,6 @@ func (db *DB) Stats() Stats {
 	return db.stats
 }
 
-// Check performs several consistency checks on the database.
-// An error is returned if any inconsistency is found.
-func (db *DB) Check() error {
-	return db.Update(func(tx *Tx) error {
-		return tx.Check()
-	})
-}
-
 // This is for internal access to the raw data bytes from the C cursor, use
 // carefully, or not at all.
 func (db *DB) Info() *Info {


### PR DESCRIPTION
This commit removes the DB.Check() function and instead makes the user decide whether a transaction should be writable or read-only. Tx.Check() is not safe to use concurrently on a read-only transaction, however, it significantly improves the performance of it.

/cc @snormore @mkobetic
