### PR TITLE
Add circular dependency integrity check.

### DIFF
--- a/node.go
+++ b/node.go
@@ -192,6 +192,7 @@ func (n *node) write(p *page) {
 			elem.pos = uint32(uintptr(unsafe.Pointer(&b[0])) - uintptr(unsafe.Pointer(elem)))
 			elem.ksize = uint32(len(item.key))
 			elem.pgid = item.pgid
+			_assert(elem.pgid != p.id, "write: circular dependency occurred")
 		}
 
 		// Write data for the element to the end of the page.


### PR DESCRIPTION
This commit adds a check to prevent circular dependencies in branch nodes. If a circular dependency occurs then a panic will be called and the commit will be prevented. This only works for a single branch level and will not recursively search the tree.

/cc @snormore @mkobetic
