### PR TITLE
Add streaming check.

### DIFF
--- a/db.go
+++ b/db.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -630,23 +629,6 @@ func (m *meta) sum64() uint64 {
 	var h = fnv.New64a()
 	_, _ = h.Write((*[unsafe.Offsetof(meta{}.checksum)]byte)(unsafe.Pointer(m))[:])
 	return h.Sum64()
-}
-
-// ErrorList represents a slice of errors.
-type ErrorList []error
-
-// Error returns a readable count of the errors in the list.
-func (l ErrorList) Error() string {
-	return fmt.Sprintf("%d errors occurred", len(l))
-}
-
-// join returns a error messages joined by a string.
-func (l ErrorList) join(sep string) string {
-	var a []string
-	for _, e := range l {
-		a = append(a, e.Error())
-	}
-	return strings.Join(a, sep)
 }
 
 // _assert will panic with a given formatted message if the given condition is false.

--- a/db_test.go
+++ b/db_test.go
@@ -53,12 +53,12 @@ func TestOpen_Check(t *testing.T) {
 	withTempPath(func(path string) {
 		db, err := Open(path, 0666)
 		assert.NoError(t, err)
-		assert.NoError(t, db.View(func(tx *Tx) error { return tx.Check() }))
+		assert.NoError(t, db.View(func(tx *Tx) error { return <-tx.Check() }))
 		db.Close()
 
 		db, err = Open(path, 0666)
 		assert.NoError(t, err)
-		assert.NoError(t, db.View(func(tx *Tx) error { return tx.Check() }))
+		assert.NoError(t, db.View(func(tx *Tx) error { return <-tx.Check() }))
 		db.Close()
 	})
 }
@@ -464,20 +464,13 @@ func withOpenDB(fn func(*DB, string)) {
 // mustCheck runs a consistency check on the database and panics if any errors are found.
 func mustCheck(db *DB) {
 	err := db.Update(func(tx *Tx) error {
-		return tx.Check()
+		return <-tx.Check()
 	})
 	if err != nil {
 		// Copy db off first.
 		var path = tempfile()
 		db.View(func(tx *Tx) error { return tx.CopyFile(path, 0600) })
-
-		if errors, ok := err.(ErrorList); ok {
-			for _, err := range errors {
-				warn(err)
-			}
-		}
-		warn(err)
-		panic("check failure: " + path)
+		panic("check failure: " + err.Error() + ": " + path)
 	}
 }
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -310,7 +310,7 @@ func TestTx_Check_Corrupt(t *testing.T) {
 		})
 	}()
 
-	assert.Equal(t, "check fail: 1 errors occurred: page 3: already freed", msg)
+	assert.Equal(t, "check fail: page 3: already freed", msg)
 }
 
 // Ensure that the database can be copied to a file path.


### PR DESCRIPTION
This commit changes Tx.Check() to return a channel through which check errors are returned. This allows errors to be found before checking the entire data file.

_Note: This does require an API change._

/cc @snormore @mkobetic
