### PR TITLE
Optimize Tx.Check().

### DIFF
--- a/cmd/bolt/check.go
+++ b/cmd/bolt/check.go
@@ -38,7 +38,7 @@ func Check(path string) {
 
 		// Print summary of errors.
 		if count > 0 {
-			fatalf("%d errors found")
+			fatalf("%d errors found", count)
 		} else {
 			println("OK")
 		}

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -10,11 +10,13 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/codegangsta/cli"
+	// "github.com/davecheney/profile"
 )
 
 var branch, commit string
 
 func main() {
+	// defer profile.Start(&profile.Config{CPUProfile: true, MemProfile: true}).Stop()
 	log.SetFlags(0)
 	NewApp().Run(os.Args)
 }


### PR DESCRIPTION
This commit removes several memory allocations occurring on every page and also caches the freelist map used when iterating over the pages. This results in significantly better performance.

_See line notes for additional details._

/cc @snormore @mkobetic
