### PR TITLE
Fix double free in merge-left rebalance.

### DIFF
--- a/node.go
+++ b/node.go
@@ -486,7 +486,6 @@ func (n *node) rebalance() {
 		target.inodes = append(target.inodes, n.inodes...)
 		n.parent.del(n.key)
 		n.parent.removeChild(n)
-		n.parent.put(target.key, target.inodes[0].key, nil, target.pgid, 0)
 		delete(n.bucket.nodes, n.pgid)
 		n.free()
 	}


### PR DESCRIPTION
This commit fixes a bug where deletions that caused merge-left rebalances were updating the parent node which caused a node to "reappear" even after it had been deleted. This was fixed in merge-right rebalances a while ago but merge-left is less frequent so it was missed until now.

Many thanks to Jordan Sherer (@jsherer) for finding and reporting the bug.

Fixes #184.
