### PR TITLE
Increase max nodes per page.

### DIFF
--- a/page.go
+++ b/page.go
@@ -10,7 +10,6 @@ const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
 
 const maxAllocSize = 0xFFFFFFF
 const minKeysPerPage = 2
-const maxNodesPerPage = 65535
 
 const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))
 const leafPageElementSize = int(unsafe.Sizeof(leafPageElement{}))
@@ -57,23 +56,23 @@ func (p *page) meta() *meta {
 
 // leafPageElement retrieves the leaf node by index
 func (p *page) leafPageElement(index uint16) *leafPageElement {
-	n := &((*[maxNodesPerPage]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	n := &((*[0xFFFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
 	return n
 }
 
 // leafPageElements retrieves a list of leaf nodes.
 func (p *page) leafPageElements() []leafPageElement {
-	return ((*[maxNodesPerPage]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return ((*[0xFFFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
 // branchPageElement retrieves the branch node by index
 func (p *page) branchPageElement(index uint16) *branchPageElement {
-	return &((*[maxNodesPerPage]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	return &((*[0xFFFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
 }
 
 // branchPageElements retrieves a list of branch nodes.
 func (p *page) branchPageElements() []branchPageElement {
-	return ((*[maxNodesPerPage]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return ((*[0xFFFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
 // dump writes n bytes of the page to STDERR as hex output.


### PR DESCRIPTION
## Overview

This commit effectively removes the `maxNodesPerPage` constant so that it is essentially unlimited. Previously, a single large transaction could create more nodes than the mock array could handle which would cause a panic.
## Notes

The `maxNodesPerPage` previously existed with a value of 64K because a page's inode count is limited by the range of a `uint16`. However, this doesn't account for the fact that nodes could grow larger than this during a large transaction and then would be split before being written to disk.

Fixes #188.

---

/cc @PreetamJinka @snormore @mkobetic
