### PR TITLE
Fix i686 build error.

### DIFF
--- a/page.go
+++ b/page.go
@@ -56,23 +56,23 @@ func (p *page) meta() *meta {
 
 // leafPageElement retrieves the leaf node by index
 func (p *page) leafPageElement(index uint16) *leafPageElement {
-	n := &((*[0xFFFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	n := &((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
 	return n
 }
 
 // leafPageElements retrieves a list of leaf nodes.
 func (p *page) leafPageElements() []leafPageElement {
-	return ((*[0xFFFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return ((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
 // branchPageElement retrieves the branch node by index
 func (p *page) branchPageElement(index uint16) *branchPageElement {
-	return &((*[0xFFFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
 }
 
 // branchPageElements retrieves a list of branch nodes.
 func (p *page) branchPageElements() []branchPageElement {
-	return ((*[0xFFFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
+	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
 // dump writes n bytes of the page to STDERR as hex output.


### PR DESCRIPTION
## Overview

The use of `0xFFFFFFF` for the size of a byte array causes the build error:

```
type [268435455]leafPageElement too large
```

This commit changes the byte array size to `0x7FFFFFF`.
## Notes

Thanks to @ernado for reporting the issue and thanks to @mux0r for providing the fix. This change does not affect amd64.

Fixes #195
