### PR TITLE
Fix split-merge regression.

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -691,15 +691,15 @@ func TestBucket_Stats_RandomFill(t *testing.T) {
 			s := tx.Bucket([]byte("woojits")).Stats()
 			assert.Equal(t, 100000, s.KeyN, "KeyN")
 
-			assert.Equal(t, 22, s.BranchPageN, "BranchPageN")
+			assert.Equal(t, 98, s.BranchPageN, "BranchPageN")
 			assert.Equal(t, 0, s.BranchOverflowN, "BranchOverflowN")
-			assert.Equal(t, 61708, s.BranchInuse, "BranchInuse")
-			assert.Equal(t, 90112, s.BranchAlloc, "BranchAlloc")
+			assert.Equal(t, 130984, s.BranchInuse, "BranchInuse")
+			assert.Equal(t, 401408, s.BranchAlloc, "BranchAlloc")
 
-			assert.Equal(t, 1643, s.LeafPageN, "LeafPageN")
+			assert.Equal(t, 3412, s.LeafPageN, "LeafPageN")
 			assert.Equal(t, 0, s.LeafOverflowN, "LeafOverflowN")
-			assert.Equal(t, 4714178, s.LeafInuse, "LeafInuse")
-			assert.Equal(t, 6729728, s.LeafAlloc, "LeafAlloc")
+			assert.Equal(t, 4742482, s.LeafInuse, "LeafInuse")
+			assert.Equal(t, 13975552, s.LeafAlloc, "LeafAlloc")
 			return nil
 		})
 	})
@@ -847,11 +847,11 @@ func TestBucket_Stats_Large(t *testing.T) {
 
 	withOpenDB(func(db *DB, path string) {
 		var index int
-		for i := 0; i < 10000; i++ {
+		for i := 0; i < 100; i++ {
 			db.Update(func(tx *Tx) error {
 				// Add bucket with lots of keys.
 				b, _ := tx.CreateBucketIfNotExists([]byte("widgets"))
-				for i := 0; i < 10; i++ {
+				for i := 0; i < 1000; i++ {
 					b.Put([]byte(strconv.Itoa(index)), []byte(strconv.Itoa(index)))
 					index++
 				}
@@ -865,16 +865,16 @@ func TestBucket_Stats_Large(t *testing.T) {
 			stats := b.Stats()
 			assert.Equal(t, 13, stats.BranchPageN, "BranchPageN")
 			assert.Equal(t, 0, stats.BranchOverflowN, "BranchOverflowN")
-			assert.Equal(t, 1195, stats.LeafPageN, "LeafPageN")
+			assert.Equal(t, 1196, stats.LeafPageN, "LeafPageN")
 			assert.Equal(t, 0, stats.LeafOverflowN, "LeafOverflowN")
 			assert.Equal(t, 100000, stats.KeyN, "KeyN")
 			assert.Equal(t, 3, stats.Depth, "Depth")
-			assert.Equal(t, 25208, stats.BranchInuse, "BranchInuse")
-			assert.Equal(t, 2596900, stats.LeafInuse, "LeafInuse")
+			assert.Equal(t, 25257, stats.BranchInuse, "BranchInuse")
+			assert.Equal(t, 2596916, stats.LeafInuse, "LeafInuse")
 			if os.Getpagesize() == 4096 {
 				// Incompatible page size
 				assert.Equal(t, 53248, stats.BranchAlloc, "BranchAlloc")
-				assert.Equal(t, 4894720, stats.LeafAlloc, "LeafAlloc")
+				assert.Equal(t, 4898816, stats.LeafAlloc, "LeafAlloc")
 			}
 			assert.Equal(t, 1, stats.BucketN, "BucketN")
 			assert.Equal(t, 0, stats.InlineBucketN, "InlineBucketN")

--- a/db.go
+++ b/db.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"unsafe"
 )
@@ -651,4 +653,9 @@ func warn(v ...interface{}) {
 
 func warnf(msg string, v ...interface{}) {
 	fmt.Fprintf(os.Stderr, msg+"\n", v...)
+}
+
+func printstack() {
+	stack := strings.Join(strings.Split(string(debug.Stack()), "\n")[2:], "\n")
+	fmt.Fprintln(os.Stderr, stack)
 }

--- a/db_test.go
+++ b/db_test.go
@@ -512,7 +512,7 @@ func withOpenDB(fn func(*DB, string)) {
 
 // mustCheck runs a consistency check on the database and panics if any errors are found.
 func mustCheck(db *DB) {
-	err := db.Update(func(tx *Tx) error {
+	err := db.View(func(tx *Tx) error {
 		return <-tx.Check()
 	})
 	if err != nil {


### PR DESCRIPTION
## Overview

This commit reverts [split-merge](https://github.com/boltdb/bolt/pull/181) and fixes the node.split() to do a multi-page split. This issue caused problems with bulk loading because it would split into a small page and a very large page. The very large page, in turn, would be an arbitrary size so when it was freed later it would be difficult to reuse and would cause serious fragmentation issues.

Reverting split-merge will cause poor utilization when randomly inserting with a high `DB.FillPercent`. My suggestion is to just use the default `DB.FillPercent` unless you know you'll only be doing sequential inserts.
## Notes

Thanks to @PreetamJinka for [reporting the issue](https://github.com/boltdb/bolt/issues/192) and thanks to @mkobetic for confirming through other testing.

---

Fixes #196.

/cc @snormore
