### PR TITLE
Change Bucket.NextSequence() to return uint64

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -39,10 +39,6 @@ var (
 	// on an existing non-bucket key or when trying to create or delete a
 	// non-bucket key on an existing bucket key.
 	ErrIncompatibleValue = errors.New("incompatible value")
-
-	// ErrSequenceOverflow is returned when the next sequence number will be
-	// larger than the maximum integer size.
-	ErrSequenceOverflow = errors.New("sequence overflow")
 )
 
 const (
@@ -336,23 +332,16 @@ func (b *Bucket) Delete(key []byte) error {
 }
 
 // NextSequence returns an autoincrementing integer for the bucket.
-func (b *Bucket) NextSequence() (int, error) {
+func (b *Bucket) NextSequence() (uint64, error) {
 	if b.tx.db == nil {
 		return 0, ErrTxClosed
 	} else if !b.Writable() {
 		return 0, ErrTxNotWritable
 	}
 
-	// Make sure next sequence number will not be larger than the maximum
-	// integer size of the system.
-	if b.bucket.sequence == uint64(maxInt) {
-		return 0, ErrSequenceOverflow
-	}
-
 	// Increment and return the sequence.
 	b.bucket.sequence++
-
-	return int(b.bucket.sequence), nil
+	return b.bucket.sequence, nil
 }
 
 // ForEach executes a function for each key/value pair in a bucket.

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -451,15 +451,15 @@ func TestBucket_NextSequence(t *testing.T) {
 			// Make sure sequence increments.
 			seq, err := tx.Bucket([]byte("widgets")).NextSequence()
 			assert.NoError(t, err)
-			assert.Equal(t, seq, 1)
+			assert.Equal(t, seq, uint64(1))
 			seq, err = tx.Bucket([]byte("widgets")).NextSequence()
 			assert.NoError(t, err)
-			assert.Equal(t, seq, 2)
+			assert.Equal(t, seq, uint64(2))
 
 			// Buckets should be separate.
 			seq, err = tx.Bucket([]byte("woojits")).NextSequence()
 			assert.NoError(t, err)
-			assert.Equal(t, seq, 1)
+			assert.Equal(t, seq, uint64(1))
 			return nil
 		})
 	})
@@ -475,26 +475,8 @@ func TestBucket_NextSequence_ReadOnly(t *testing.T) {
 		db.View(func(tx *Tx) error {
 			b := tx.Bucket([]byte("widgets"))
 			i, err := b.NextSequence()
-			assert.Equal(t, i, 0)
+			assert.Equal(t, i, uint64(0))
 			assert.Equal(t, err, ErrTxNotWritable)
-			return nil
-		})
-	})
-}
-
-// Ensure that incrementing past the maximum sequence number will return an error.
-func TestBucket_NextSequence_Overflow(t *testing.T) {
-	withOpenDB(func(db *DB, path string) {
-		db.Update(func(tx *Tx) error {
-			tx.CreateBucket([]byte("widgets"))
-			return nil
-		})
-		db.Update(func(tx *Tx) error {
-			b := tx.Bucket([]byte("widgets"))
-			b.bucket.sequence = uint64(maxInt)
-			seq, err := b.NextSequence()
-			assert.Equal(t, err, ErrSequenceOverflow)
-			assert.Equal(t, seq, 0)
 			return nil
 		})
 	})


### PR DESCRIPTION
This commit changes NextSequence() to return a uint64 instead of an int. This also removes the ErrSequenceOverflow error condition since overflowing a uint64 is unlikely.

Fixes #39.

/cc @tv42 @extemporalgenome
