### PR TITLE
Add DefaultOptions variable.

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -2,7 +2,6 @@ package bolt
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -13,32 +12,6 @@ const (
 
 	// MaxValueSize is the maximum length of a value, in bytes.
 	MaxValueSize = 4294967295
-)
-
-var (
-	// ErrBucketNotFound is returned when trying to access a bucket that has
-	// not been created yet.
-	ErrBucketNotFound = errors.New("bucket not found")
-
-	// ErrBucketExists is returned when creating a bucket that already exists.
-	ErrBucketExists = errors.New("bucket already exists")
-
-	// ErrBucketNameRequired is returned when creating a bucket with a blank name.
-	ErrBucketNameRequired = errors.New("bucket name required")
-
-	// ErrKeyRequired is returned when inserting a zero-length key.
-	ErrKeyRequired = errors.New("key required")
-
-	// ErrKeyTooLarge is returned when inserting a key that is larger than MaxKeySize.
-	ErrKeyTooLarge = errors.New("key too large")
-
-	// ErrValueTooLarge is returned when inserting a value that is larger than MaxValueSize.
-	ErrValueTooLarge = errors.New("value too large")
-
-	// ErrIncompatibleValue is returned when trying create or delete a bucket
-	// on an existing non-bucket key or when trying to create or delete a
-	// non-bucket key on an existing bucket key.
-	ErrIncompatibleValue = errors.New("incompatible value")
 )
 
 const (

--- a/db.go
+++ b/db.go
@@ -1,7 +1,6 @@
 package bolt
 
 import (
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -32,30 +31,6 @@ const (
 // DefaultFillPercent is the percentage that split pages are filled.
 // This value can be changed by setting DB.FillPercent.
 const DefaultFillPercent = 0.5
-
-var (
-	// ErrDatabaseNotOpen is returned when a DB instance is accessed before it
-	// is opened or after it is closed.
-	ErrDatabaseNotOpen = errors.New("database not open")
-
-	// ErrDatabaseOpen is returned when opening a database that is
-	// already open.
-	ErrDatabaseOpen = errors.New("database already open")
-
-	// ErrInvalid is returned when a data file is not a Bolt-formatted database.
-	ErrInvalid = errors.New("invalid database")
-
-	// ErrVersionMismatch is returned when the data file was created with a
-	// different version of Bolt.
-	ErrVersionMismatch = errors.New("version mismatch")
-
-	// ErrChecksum is returned when either meta page checksum does not match.
-	ErrChecksum = errors.New("checksum error")
-
-	// ErrTimeout is returned when a database cannot obtain an exclusive lock
-	// on the data file after the timeout passed to Open().
-	ErrTimeout = errors.New("timeout")
-)
 
 // DB represents a collection of buckets persisted to a file on disk.
 // All data access is performed through transactions which can be obtained through the DB.
@@ -117,9 +92,9 @@ func (db *DB) String() string {
 func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	var db = &DB{opened: true, FillPercent: DefaultFillPercent}
 
-	// Set default options.
+	// Set default options if no options are provided.
 	if options == nil {
-		options = &Options{}
+		options = DefaultOptions
 	}
 
 	// Open data file and separate sync handler for metadata writes.
@@ -573,6 +548,12 @@ type Options struct {
 	// When set to zero it will wait indefinitely. This option is only
 	// available on Darwin and Linux.
 	Timeout time.Duration
+}
+
+// DefaultOptions represent the options used if nil options are passed into Open().
+// No timeout is used which will cause Bolt to wait indefinitely for a lock.
+var DefaultOptions = &Options{
+	Timeout: 0,
 }
 
 // Stats represents statistics about the database.

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,70 @@
+package bolt
+
+import "errors"
+
+// These errors can be returned when opening or calling methods on a DB.
+var (
+	// ErrDatabaseNotOpen is returned when a DB instance is accessed before it
+	// is opened or after it is closed.
+	ErrDatabaseNotOpen = errors.New("database not open")
+
+	// ErrDatabaseOpen is returned when opening a database that is
+	// already open.
+	ErrDatabaseOpen = errors.New("database already open")
+
+	// ErrInvalid is returned when a data file is not a Bolt-formatted database.
+	ErrInvalid = errors.New("invalid database")
+
+	// ErrVersionMismatch is returned when the data file was created with a
+	// different version of Bolt.
+	ErrVersionMismatch = errors.New("version mismatch")
+
+	// ErrChecksum is returned when either meta page checksum does not match.
+	ErrChecksum = errors.New("checksum error")
+
+	// ErrTimeout is returned when a database cannot obtain an exclusive lock
+	// on the data file after the timeout passed to Open().
+	ErrTimeout = errors.New("timeout")
+)
+
+// These errors can occur when beginning or committing a Tx.
+var (
+	// ErrTxNotWritable is returned when performing a write operation on a
+	// read-only transaction.
+	ErrTxNotWritable = errors.New("tx not writable")
+
+	// ErrTxClosed is returned when committing or rolling back a transaction
+	// that has already been committed or rolled back.
+	ErrTxClosed = errors.New("tx closed")
+
+	// ErrFreelistOverflow is returned when the total number of free pages
+	// exceeds 65,536 and the freelist cannot hold any more.
+	ErrFreelistOverflow = errors.New("freelist overflow")
+)
+
+// These errors can occur when putting or deleting a value or a bucket.
+var (
+	// ErrBucketNotFound is returned when trying to access a bucket that has
+	// not been created yet.
+	ErrBucketNotFound = errors.New("bucket not found")
+
+	// ErrBucketExists is returned when creating a bucket that already exists.
+	ErrBucketExists = errors.New("bucket already exists")
+
+	// ErrBucketNameRequired is returned when creating a bucket with a blank name.
+	ErrBucketNameRequired = errors.New("bucket name required")
+
+	// ErrKeyRequired is returned when inserting a zero-length key.
+	ErrKeyRequired = errors.New("key required")
+
+	// ErrKeyTooLarge is returned when inserting a key that is larger than MaxKeySize.
+	ErrKeyTooLarge = errors.New("key too large")
+
+	// ErrValueTooLarge is returned when inserting a value that is larger than MaxValueSize.
+	ErrValueTooLarge = errors.New("value too large")
+
+	// ErrIncompatibleValue is returned when trying create or delete a bucket
+	// on an existing non-bucket key or when trying to create or delete a
+	// non-bucket key on an existing bucket key.
+	ErrIncompatibleValue = errors.New("incompatible value")
+)

--- a/freelist.go
+++ b/freelist.go
@@ -1,16 +1,9 @@
 package bolt
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"unsafe"
-)
-
-var (
-	// ErrFreelistOverflow is returned when the total number of free pages
-	// exceeds 65,536 and the freelist cannot hold any more.
-	ErrFreelistOverflow = errors.New("freelist overflow")
 )
 
 // freelist represents a list of all pages that are available for allocation.

--- a/tx.go
+++ b/tx.go
@@ -1,23 +1,12 @@
 package bolt
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sort"
 	"time"
 	"unsafe"
-)
-
-var (
-	// ErrTxNotWritable is returned when performing a write operation on a
-	// read-only transaction.
-	ErrTxNotWritable = errors.New("tx not writable")
-
-	// ErrTxClosed is returned when committing or rolling back a transaction
-	// that has already been committed or rolled back.
-	ErrTxClosed = errors.New("tx closed")
 )
 
 // txid represents the internal transaction identifier.


### PR DESCRIPTION
This commit adds an explicit `DefaultOptions` variable for additional documentation. `Open()` can still be passed a nil options which will cause options to be change to the `DefaultOptions` variable. This change also allows options to be set globally for an application if more than one database is being opened in a process.

This commit also moves all errors to errors.go so that the godoc groups them together.

/cc @tsenart
