### PR TITLE
Recover from panics appropriately.

### DIFF
--- a/db.go
+++ b/db.go
@@ -440,6 +440,13 @@ func (db *DB) Update(fn func(*Tx) error) error {
 		return err
 	}
 
+	// Make sure the transaction rolls back in the event of a panic.
+	defer func() {
+		if t.db != nil {
+			t.rollback()
+		}
+	}()
+
 	// Mark as a managed tx so that the inner function cannot manually commit.
 	t.managed = true
 
@@ -463,6 +470,13 @@ func (db *DB) View(fn func(*Tx) error) error {
 	if err != nil {
 		return err
 	}
+
+	// Make sure the transaction rolls back in the event of a panic.
+	defer func() {
+		if t.db != nil {
+			t.rollback()
+		}
+	}()
 
 	// Mark as a managed tx so that the inner function cannot manually rollback.
 	t.managed = true

--- a/tx.go
+++ b/tx.go
@@ -212,6 +212,9 @@ func (tx *Tx) Rollback() error {
 }
 
 func (tx *Tx) rollback() {
+	if tx.db == nil {
+		return
+	}
 	if tx.writable {
 		tx.db.freelist.rollback(tx.id())
 		tx.db.freelist.reload(tx.db.page(tx.db.meta().freelist))
@@ -220,6 +223,9 @@ func (tx *Tx) rollback() {
 }
 
 func (tx *Tx) close() {
+	if tx.db == nil {
+		return
+	}
 	if tx.writable {
 		// Grab freelist stats.
 		var freelistFreeN = tx.db.freelist.free_count()


### PR DESCRIPTION
## Overview

This commit adds a defer handler to ensure that transactions are always closed out - even in the event of a panic within user code. It's recommended that applications always fail in the event of a panic but some packages such as net/http will automatically recover which is a problem (IHMO).

/cc @snormore @mkobetic
