### PR TITLE
Fixed cast for 32-bit windows.

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -35,7 +35,7 @@ func mmap(db *DB, sz int) error {
 
 	// Open a file mapping handle.
 	sizelo := uint32(sz >> 32)
-	sizehi := uint32(sz & 0xffffffff)
+	sizehi := uint32(sz) & 0xffffffff
 	h, errno := syscall.CreateFileMapping(syscall.Handle(db.file.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
 	if h == 0 {
 		return os.NewSyscallError("CreateFileMapping", errno)


### PR DESCRIPTION
Got an error cross-compiling to windows 386:

```
../../../../boltdb/bolt/bolt_windows.go:38: constant 4294967295 overflows int
```

Updated int cast.
