### PR TITLE
Only update rebalance time if nodes are rebalanced

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -141,7 +141,9 @@ func (tx *Tx) Commit() error {
 	// Rebalance nodes which have had deletions.
 	var startTime = time.Now()
 	tx.root.rebalance()
-	tx.stats.RebalanceTime += time.Since(startTime)
+	if tx.stats.Rebalance > 0 {
+		tx.stats.RebalanceTime += time.Since(startTime)
+	}
 
 	// spill data onto dirty pages.
 	startTime = time.Now()


### PR DESCRIPTION
This commit changes TxStats.RebalanceTime to only update if there are nodes that have been rebalanced. Previously, the RebalanceTime would include a small amount of time to check if there were nodes to rebalance but this is confusing to users and not terribly helpful.

/cc @mkobetic
