### PR TITLE
Fix root split on very large append.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -608,15 +608,36 @@ func withOpenDB(fn func(*DB, string)) {
 
 // mustCheck runs a consistency check on the database and panics if any errors are found.
 func mustCheck(db *DB) {
-	err := db.View(func(tx *Tx) error {
-		return <-tx.Check()
+	db.View(func(tx *Tx) error {
+		// Collect all the errors.
+		var errors []error
+		for err := range tx.Check() {
+			errors = append(errors, err)
+			if len(errors) > 10 {
+				break
+			}
+		}
+
+		// If errors occurred, copy the DB and print the errors.
+		if len(errors) > 0 {
+			var path = tempfile()
+			tx.CopyFile(path, 0600)
+
+			// Print errors.
+			fmt.Print("\n\n")
+			fmt.Printf("consistency check failed (%d errors)\n", len(errors))
+			for _, err := range errors {
+				fmt.Println(err)
+			}
+			fmt.Println("")
+			fmt.Println("db saved to:")
+			fmt.Println(path)
+			fmt.Print("\n\n")
+			os.Exit(-1)
+		}
+
+		return nil
 	})
-	if err != nil {
-		// Copy db off first.
-		var path = tempfile()
-		db.View(func(tx *Tx) error { return tx.CopyFile(path, 0600) })
-		panic("check failure: " + err.Error() + ": " + path)
-	}
 }
 
 // mustContainKeys checks that a bucket contains a given set of keys.


### PR DESCRIPTION
This commit fixes a bug where a root split on a very large insert would cause an overflow of the root node. The problem was that the new root was not split when it was created so a new root with more than 64K child nodes would overflow the `page.count` (uint16).

This problem would occur when appending ~200,000 500 byte key/value pairs into a single bucket in a single transaction. This issue was previously prevented because the freelist overflow error and the double spill would rollback this kind of transaction.

See line notes for more info.

/cc @mkobetic @snormore
