### PR TITLE
Fix split root dereference.

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -645,7 +645,7 @@ func (b *Bucket) free() {
 // dereference removes all references to the old mmap.
 func (b *Bucket) dereference() {
 	if b.rootNode != nil {
-		b.rootNode.dereference()
+		b.rootNode.root().dereference()
 	}
 
 	for _, child := range b.buckets {


### PR DESCRIPTION
This commit fixes a bug that occurs when a root node is split just after a re-mmap occurs. Previously, this would cause a panic because the new root node would still reference keys from the old mmap.

_Note: This only caused a panic and did not result in any data loss or corruption._

/cc @mkobetic @snormore
