### PR TITLE
Add caveat for memory usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,13 @@ Here are a few things to note when evaluating and using Bolt:
   more than 100,000 key/value pairs into a single new bucket in a single
   transaction is not advised.
 
+* Bolt uses a memory-mapped file so the underlying operating system handles the
+  caching of the data. Typically, the OS will cache as much of the file as it
+  can in memory and will release memory as needed to other processes. This means
+  that Bolt can show very high memory usage when working with large databases.
+  However, this is expected and the OS will release memory as needed. Bolt can
+  handle databases much larger than the available physical RAM.
+
 
 ## Other Projects Using Bolt
 


### PR DESCRIPTION
This pull request adds a caveat for high memory usage shown by processes with large Bolt databases. This is expected behavior and is handled by the OS page cache.

---

Fixes #253.

/cc @bobrik
