### PR TITLE
Rework build to support more liberal unix variants.

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build !windows,!plan9
 
 package bolt
 

--- a/boltsync_unix.go
+++ b/boltsync_unix.go
@@ -1,3 +1,5 @@
+// +build !windows,!plan9,!linux
+
 package bolt
 
 import (


### PR DESCRIPTION
Rather than having the build setup such that it will only work on the
specifically defined operating systems, this commit modifies it to use
more liberal !windows,!plan9 build tag for the unix specific bits.

This means bolt will compile on more Operating Systems such as OpenBSD,
FreeBSD, and NetBSD.

See boltdb/bolt#257 for discussion.

I've tested these changes with cross compilation to windows, darwin, linux, openbsd, and freebsd.

It should also work fine for NetBSD and DragonFly BSD, but I did not test those.
