### PR TITLE
freeing buffers after allocation new memory and writing meta information...

### DIFF
--- a/db.go
+++ b/db.go
@@ -538,6 +538,9 @@ func (db *DB) meta() *meta {
 func (db *DB) allocate(count int) (*page, error) {
 	// Allocate a temporary buffer for the page.
 	buf := make([]byte, count*db.pageSize)
+	defer func() {
+		buf = nil
+	}()
 	p := (*page)(unsafe.Pointer(&buf[0]))
 	p.overflow = uint32(count - 1)
 

--- a/tx.go
+++ b/tx.go
@@ -441,6 +441,9 @@ func (tx *Tx) write() error {
 func (tx *Tx) writeMeta() error {
 	// Create a temporary buffer for the meta page.
 	buf := make([]byte, tx.db.pageSize)
+	defer func() {
+		buf = nil
+	}()
 	p := tx.db.pageInBuffer(buf, 0)
 	tx.meta.write(p)
 


### PR DESCRIPTION
Those allocations cause to bug memory consumption. Those buffers were not released by GC. Until new gc in 1.4 this nil assignment is mandatory for big data structures.
