### PR TITLE
Raise maxMapSize from 256MB to 2GB on 386, arm.

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -1,4 +1,4 @@
 package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFF // 256MB
+const maxMapSize = 0x7FFFFFFF // 2GB

--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -1,4 +1,4 @@
 package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFF // 256MB
+const maxMapSize = 0x7FFFFFFF // 2GB


### PR DESCRIPTION
Fixes #260 and #277.