### PR TITLE
Fix syntax error in README stats example

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@ go func() {
 		// Save stats for the next loop.
 		prev = stats
 	}
-}
 }()
 ```
 


### PR DESCRIPTION
There was one curly brace too much