### PR TITLE
fix 'range scans' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ db.View(func(tx *bolt.Tx) error {
 	max := []byte("2000-01-01T00:00:00Z")
 
 	// Iterate over the 90's.
-	for k, v := c.Seek(min); k != nil && bytes.Compare(k, max) != -1; k, v = c.Next() {
+	for k, v := c.Seek(min); k != nil && bytes.Compare(k, max) <= 0; k, v = c.Next() {
 		fmt.Printf("%s: %s\n", k, v)
 	}
 


### PR DESCRIPTION
Due to the fact that you want to iterate over all keys that are before or equal to `max` starting from `min` the bytes.Compare() check should look like the commit suggests.