### PR TITLE
Fix mmap resize calculation.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -94,23 +94,30 @@ func TestOpen_Size(t *testing.T) {
 	defer db.Close()
 
 	// Insert until we get above the minimum 4MB size.
-	db.Update(func(tx *bolt.Tx) error {
+	ok(t, db.Update(func(tx *bolt.Tx) error {
 		b, _ := tx.CreateBucketIfNotExists([]byte("data"))
 		for i := 0; i < 10000; i++ {
-			_ = b.Put([]byte(fmt.Sprintf("%04d", i)), make([]byte, 1000))
+			ok(t, b.Put([]byte(fmt.Sprintf("%04d", i)), make([]byte, 1000)))
 		}
 		return nil
-	})
+	}))
 
 	// Close database and grab the size.
 	db.DB.Close()
 	sz := fileSize(path)
+	if sz == 0 {
+		t.Fatalf("unexpected new file size: %d", sz)
+	}
 
 	// Reopen database, update, and check size again.
-	db0, _ := bolt.Open(path, 0666, nil)
-	db0.Update(func(tx *bolt.Tx) error { return tx.Bucket([]byte("data")).Put([]byte{0}, []byte{0}) })
-	db0.Close()
+	db0, err := bolt.Open(path, 0666, nil)
+	ok(t, err)
+	ok(t, db0.Update(func(tx *bolt.Tx) error { return tx.Bucket([]byte("data")).Put([]byte{0}, []byte{0}) }))
+	ok(t, db0.Close())
 	newSz := fileSize(path)
+	if newSz == 0 {
+		t.Fatalf("unexpected new file size: %d", newSz)
+	}
 
 	// Compare the original size with the new size.
 	if sz != newSz {


### PR DESCRIPTION
## Overview

This pull request fixes an issue where the database would grow whenever it was opened. This was caused by a recent change that performed a truncation when the database grew. Now there are fixed growth sizes for the database (1MB, 2MB, 4MB, 8MB, etc) up to 1GB and then the database will grow by 1GB when it resizes.

See also: 6bb25854a183f3d3bfa50096f910d3a3984e9834

Fixes: #291

/cc @kemist 