### PR TITLE
Expand assertion statements

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 )
 
@@ -228,8 +229,8 @@ func (c *Cursor) next() (key []byte, value []byte, flags uint32) {
 // search recursively performs a binary search against a given page/node until it finds a given key.
 func (c *Cursor) search(key []byte, pgid pgid) {
 	p, n := c.bucket.pageNode(pgid)
-	if p != nil {
-		_assert((p.flags&(branchPageFlag|leafPageFlag)) != 0, "invalid page type: %d: %x", p.id, p.flags)
+	if p != nil && (p.flags&(branchPageFlag|leafPageFlag)) == 0 {
+		panic(fmt.Sprintf("invalid page type: %d: %x", p.id, p.flags))
 	}
 	e := elemRef{page: p, node: n}
 	c.stack = append(c.stack, e)

--- a/db.go
+++ b/db.go
@@ -664,9 +664,11 @@ func (m *meta) copy(dest *meta) {
 
 // write writes the meta onto a page.
 func (m *meta) write(p *page) {
-
-	_assert(m.root.root < m.pgid, "root bucket pgid (%d) above high water mark (%d)", m.root.root, m.pgid)
-	_assert(m.freelist < m.pgid, "freelist pgid (%d) above high water mark (%d)", m.freelist, m.pgid)
+	if m.root.root >= m.pgid {
+		panic(fmt.Sprintf("root bucket pgid (%d) above high water mark (%d)", m.root.root, m.pgid))
+	} else if m.freelist >= m.pgid {
+		panic(fmt.Sprintf("freelist pgid (%d) above high water mark (%d)", m.freelist, m.pgid))
+	}
 
 	// Page id is either going to be 0 or 1 which we can determine by the transaction ID.
 	p.id = pgid(m.txid % 2)

--- a/node.go
+++ b/node.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"unsafe"
 )
@@ -70,7 +71,9 @@ func (n *node) pageElementSize() int {
 
 // childAt returns the child node at a given index.
 func (n *node) childAt(index int) *node {
-	_assert(!n.isLeaf, "invalid childAt(%d) on a leaf node", index)
+	if n.isLeaf {
+		panic(fmt.Sprintf("invalid childAt(%d) on a leaf node", index))
+	}
 	return n.bucket.node(n.inodes[index].pgid, n)
 }
 
@@ -111,9 +114,13 @@ func (n *node) prevSibling() *node {
 
 // put inserts a key/value.
 func (n *node) put(oldKey, newKey, value []byte, pgid pgid, flags uint32) {
-	_assert(pgid < n.bucket.tx.meta.pgid, "pgid (%d) above high water mark (%d)", pgid, n.bucket.tx.meta.pgid)
-	_assert(len(oldKey) > 0, "put: zero-length old key")
-	_assert(len(newKey) > 0, "put: zero-length new key")
+	if pgid >= n.bucket.tx.meta.pgid {
+		panic(fmt.Sprintf("pgid (%d) above high water mark (%d)", pgid, n.bucket.tx.meta.pgid))
+	} else if len(oldKey) <= 0 {
+		panic("put: zero-length old key")
+	} else if len(newKey) <= 0 {
+		panic("put: zero-length new key")
+	}
 
 	// Find insertion index.
 	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, oldKey) != -1 })
@@ -189,7 +196,9 @@ func (n *node) write(p *page) {
 		p.flags |= branchPageFlag
 	}
 
-	_assert(len(n.inodes) < 0xFFFF, "inode overflow: %d (pgid=%d)", len(n.inodes), p.id)
+	if len(n.inodes) >= 0xFFFF {
+		panic(fmt.Sprintf("inode overflow: %d (pgid=%d)", len(n.inodes), p.id))
+	}
 	p.count = uint16(len(n.inodes))
 
 	// Loop over each item and write it to the page.
@@ -348,7 +357,9 @@ func (n *node) spill() error {
 		}
 
 		// Write the node.
-		_assert(p.id < tx.meta.pgid, "pgid (%d) above high water mark (%d)", p.id, tx.meta.pgid)
+		if p.id >= tx.meta.pgid {
+			panic(fmt.Sprintf("pgid (%d) above high water mark (%d)", p.id, tx.meta.pgid))
+		}
 		node.pgid = p.id
 		node.write(p)
 		node.spilled = true


### PR DESCRIPTION
## Overview

This pull request expands calls to `_assert()` that use variadic arguments. These calls require conversion to `interface{}` so there was a large number of calls to Go's internal `convT2E()` function. In some profiling this was taking over 20% of total runtime. I don't remember seeing this before Go 1.4 so perhaps something has changed. Or maybe I just didn't see it.

Note that this does not change any functionality. The changed lines of code are functionally equivalent.

---

/cc @mkobetic 