### PR TITLE
Persist sequence-only changes

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -332,6 +332,12 @@ func (b *Bucket) NextSequence() (uint64, error) {
 		return 0, ErrTxNotWritable
 	}
 
+	// Materialize the root node if it hasn't been already so that the
+	// bucket will be saved during commit.
+	if b.rootNode == nil {
+		_ = b.node(b.root, nil)
+	}
+
 	// Increment and return the sequence.
 	b.bucket.sequence++
 	return b.bucket.sequence, nil

--- a/db.go
+++ b/db.go
@@ -694,13 +694,8 @@ func _assert(condition bool, msg string, v ...interface{}) {
 	}
 }
 
-func warn(v ...interface{}) {
-	fmt.Fprintln(os.Stderr, v...)
-}
-
-func warnf(msg string, v ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg+"\n", v...)
-}
+func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
+func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }
 
 func printstack() {
 	stack := strings.Join(strings.Split(string(debug.Stack()), "\n")[2:], "\n")

--- a/db_test.go
+++ b/db_test.go
@@ -696,3 +696,6 @@ func fileSize(path string) int64 {
 	}
 	return fi.Size()
 }
+
+func warn(v ...interface{})              { fmt.Fprintln(os.Stderr, v...) }
+func warnf(msg string, v ...interface{}) { fmt.Fprintf(os.Stderr, msg+"\n", v...) }


### PR DESCRIPTION
This commit fixes a bug where only calling NextSequence() on a Bucket does not cause the Bucket to be peristed. The simple fix is to simply materialize the root node so that the bucket is flushed out during commit.

Thanks to Matthew Dawson (@MJDSys) for reporting.

Fixes #296