### PR TITLE
Fixed missing parenthesis on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ if err != nil {
 defer tx.Rollback()
 
 // Use the transaction...
-_, err := tx.CreateBucket([]byte("MyBucket")
+_, err := tx.CreateBucket([]byte("MyBucket"))
 if err != nil {
     return err
 }


### PR DESCRIPTION
Simple typo, a missing parenthesis in one of the examples of the README.