### PR TITLE
Increase max array pointer size to 2GB.

### DIFF
--- a/page.go
+++ b/page.go
@@ -8,7 +8,7 @@ import (
 
 const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
 
-const maxAllocSize = 0xFFFFFFF
+const maxAllocSize = 0x7FFFFFFF
 const minKeysPerPage = 2
 
 const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))


### PR DESCRIPTION
## Overview

This commit changes the maxAllocSize from 256GB to 2GB to handle large values. It was previously 0xFFFFFFF and I tried adding one more "F" but it caused an "array too large" error. I played around with the value some more and found that 0x7FFFFFFF (2GB) is the highest allowed value.

This does not affect how the data is stored. It is simply used for type converting pointers to array pointers in order to utilize zero copy from the mmap.

Fixes #299

/cc @stryke @denistoikka @kemist 