### PR TITLE
Update max alloc size on 386 arch

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -2,3 +2,6 @@ package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF

--- a/bolt_amd64.go
+++ b/bolt_amd64.go
@@ -2,3 +2,6 @@ package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF

--- a/page.go
+++ b/page.go
@@ -8,7 +8,6 @@ import (
 
 const pageHeaderSize = int(unsafe.Offsetof(((*page)(nil)).ptr))
 
-const maxAllocSize = 0x7FFFFFFF
 const minKeysPerPage = 2
 
 const branchPageElementSize = int(unsafe.Sizeof(branchPageElement{}))


### PR DESCRIPTION
## Overview

This pull request fixes a breaking change introduce to the 32-bit architecture in https://github.com/boltdb/bolt/pull/315. The fix is to simply revert the value of `maxAllocSize` for the 386 arch only.

---

Fixes: https://github.com/boltdb/bolt/issues/316

/cc @poffe 