### PR TITLE
new line after page size info print

### DIFF
--- a/cmd/bolt/info.go
+++ b/cmd/bolt/info.go
@@ -22,5 +22,5 @@ func Info(path string) {
 
 	// Print basic database info.
 	var info = db.Info()
-	printf("Page Size: %d", info.PageSize)
+	printf("Page Size: %d\n", info.PageSize)
 }


### PR DESCRIPTION
A new line at the end of page size info printing would be good