### PR TITLE
Added max alloc size to arm.

### DIFF
--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -2,3 +2,6 @@ package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF


### PR DESCRIPTION
Added max alloc size to the arm arch, because I was running bolt on a Pi2 and it wouldn't compile.