### PR TITLE
Add DB.NoTruncate flag.

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -44,11 +44,13 @@ func funlock(f *os.File) error {
 func mmap(db *DB, sz int) error {
 	// Truncate and fsync to ensure file size metadata is flushed.
 	// https://github.com/boltdb/bolt/issues/284
-	if err := db.file.Truncate(int64(sz)); err != nil {
-		return fmt.Errorf("file resize error: %s", err)
-	}
-	if err := db.file.Sync(); err != nil {
-		return fmt.Errorf("file sync error: %s", err)
+	if !db.NoGrowSync {
+		if err := db.file.Truncate(int64(sz)); err != nil {
+			return fmt.Errorf("file resize error: %s", err)
+		}
+		if err := db.file.Sync(); err != nil {
+			return fmt.Errorf("file sync error: %s", err)
+		}
 	}
 
 	// Map the data file to memory.


### PR DESCRIPTION
## Overview

This commit adds the `DB.NoTruncate` flag to optionally revert `mmap()` calls to how they were implemented before the ext3/ext4 fix. When `NoTruncate` is true, remapping the data file will not force the file system to resize it immediately. This works for non-ext3/4 file systems.

The default value of `NoTruncate` is `false` so it is still safe for ext3/ext4 file systems by default.

See also: https://github.com/boltdb/bolt/issues/284

/cc @tv42 @mkobetic @bouk