### PR TITLE
bucket_test: add test for ErrValueTooLarge on insert

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -640,6 +640,18 @@ func TestBucket_Put_KeyTooLarge(t *testing.T) {
 	})
 }
 
+// Ensure that an error is returned when inserting a value that's too large.
+func TestBucket_Put_ValueTooLarge(t *testing.T) {
+	db := NewTestDB()
+	defer db.Close()
+	db.Update(func(tx *bolt.Tx) error {
+		tx.CreateBucket([]byte("widgets"))
+		err := tx.Bucket([]byte("widgets")).Put([]byte("foo"), make([]byte, bolt.MaxValueSize+1))
+		equals(t, err, bolt.ErrValueTooLarge)
+		return nil
+	})
+}
+
 // Ensure a bucket can calculate stats.
 func TestBucket_Stats(t *testing.T) {
 	db := NewTestDB()


### PR DESCRIPTION
Adds test coverage for these lines: https://github.com/boltdb/bolt/blob/master/bucket.go#L283-L285

```
[zsh|matt@nerr-2]:~/git/go/src/github.com/boltdb/bolt 0 *(master) ± go test -v -run=TestBucket_Put_ValueTooLarge
seed: 46260
quick settings: count=5, items=1000, ksize=1024, vsize=1024
=== RUN TestBucket_Put_ValueTooLarge
--- PASS: TestBucket_Put_ValueTooLarge (0.40s)
PASS
ok      github.com/boltdb/bolt  0.408s
```