### PR TITLE
Return error if reading meta page fails

### DIFF
--- a/db.go
+++ b/db.go
@@ -174,6 +174,8 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 				return nil, fmt.Errorf("meta0 error: %s", err)
 			}
 			db.pageSize = int(m.pageSize)
+		} else {
+			return nil, fmt.Errorf("init error: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Returning the error that we get from reading the file when trying to get the meta page appears to resolve issue #369. 

In my testing I didn't see any downsides to doing this here, please let me know if I missed something.
