### PR TITLE
open read-only databases in read-only mode

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -48,8 +48,8 @@ func funlock(f *os.File) error {
 func mmap(db *DB, sz int) error {
 	// Truncate and fsync to ensure file size metadata is flushed.
 	// https://github.com/boltdb/bolt/issues/284
-	if !db.NoGrowSync {
-		if err := db.ops.Truncate(int64(sz)); err != nil {
+	if !db.NoGrowSync && !db.readOnly {
+		if err := db.file.Truncate(int64(sz)); err != nil {
 			return fmt.Errorf("file resize error: %s", err)
 		}
 		if err := db.file.Sync(); err != nil {

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -45,7 +45,7 @@ func mmap(db *DB, sz int) error {
 	// Truncate and fsync to ensure file size metadata is flushed.
 	// https://github.com/boltdb/bolt/issues/284
 	if !db.NoGrowSync {
-		if err := db.file.Truncate(int64(sz)); err != nil {
+		if err := db.ops.Truncate(int64(sz)); err != nil {
 			return fmt.Errorf("file resize error: %s", err)
 		}
 		if err := db.file.Sync(); err != nil {

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -28,9 +28,11 @@ func funlock(f *os.File) error {
 // mmap memory maps a DB's data file.
 // Based on: https://github.com/edsrzf/mmap-go
 func mmap(db *DB, sz int) error {
-	// Truncate the database to the size of the mmap.
-	if err := db.ops.Truncate(int64(sz)); err != nil {
-		return fmt.Errorf("truncate: %s", err)
+	if !db.readOnly {
+		// Truncate the database to the size of the mmap.
+		if err := db.file.Truncate(int64(sz)); err != nil {
+			return fmt.Errorf("truncate: %s", err)
+		}
 	}
 
 	// Open a file mapping handle.

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -29,7 +29,7 @@ func funlock(f *os.File) error {
 // Based on: https://github.com/edsrzf/mmap-go
 func mmap(db *DB, sz int) error {
 	// Truncate the database to the size of the mmap.
-	if err := db.file.Truncate(int64(sz)); err != nil {
+	if err := db.ops.Truncate(int64(sz)); err != nil {
 		return fmt.Errorf("truncate: %s", err)
 	}
 

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -16,7 +16,7 @@ func fdatasync(db *DB) error {
 }
 
 // flock acquires an advisory lock on a file descriptor.
-func flock(f *os.File, _ time.Duration) error {
+func flock(f *os.File, _ bool, _ time.Duration) error {
 	return nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -36,6 +36,10 @@ var (
 	// ErrTxClosed is returned when committing or rolling back a transaction
 	// that has already been committed or rolled back.
 	ErrTxClosed = errors.New("tx closed")
+
+	// ErrDatabaseReadOnly is returned when a mutating transaction is started on a
+	// read-only database.
+	ErrDatabaseReadOnly = errors.New("database is in read-only mode")
 )
 
 // These errors can occur when putting or deleting a value or a bucket.


### PR DESCRIPTION
allows a database to be opened by multiple processes at the same time in read-only mode.
all attempts to mutate the database result in ErrDatabaseReadOnly.
