### PR TITLE
fix for issue #275 - bucket stat key count within transaction

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -919,6 +919,20 @@ func TestBucket_Stats_Large(t *testing.T) {
 	})
 }
 
+// Ensure a bucket can calculate stats before commit.
+func TestBucket_Stats_InMemory(t *testing.T) {
+    db := NewTestDB()
+    defer db.Close()
+    db.Update(func(tx *bolt.Tx) error {
+        b, _ := tx.CreateBucketIfNotExists([]byte("woojits"))
+        b.Put([]byte("foo"), []byte("000"))
+        b.Put([]byte("bar"), []byte("000"))
+        stats := b.Stats()
+        equals(t, 2, stats.KeyN)
+        return nil
+    })
+}
+
 // Ensure that a bucket can write random keys and values across multiple transactions.
 func TestBucket_Put_Single(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Should fix issue #275.
- Replaced the iteration over each page with iteration over each page node as described by benbjohnson.
- For the node to be actually passed the latter iteration function had to be adapted for inline pages.
- The nodes key count is only taken in case the page does not provide it.
- Added the test case stated by benbjohnson for verification.
- All tests are passing on my machine.

I'm not 100 % sure if this is a good solution and that it doesn't break anything else. I did not study the project in detail yet.
However, I hope it is useful. Feedback is welcome.
