### PR TITLE
Add Consul to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,5 +609,6 @@ Below is a list of public, open source projects that use Bolt:
 * [InfluxDB](http://influxdb.com) - Scalable datastore for metrics, events, and real-time analytics.
 * [Freehold](http://tshannon.bitbucket.org/freehold/) - An open, secure, and lightweight platform for your files and data.
 * [Prometheus Annotation Server](https://github.com/oliver006/prom_annotation_server) - Annotation server for PromDash & Prometheus service monitoring system.
+* [Consul](https://github.com/hashicorp/consul) - Consul is service discovery and configuration made easy. Distributed, highly available, and datacenter-aware.
 
 If you are using Bolt in a project please send a pull request to add it to the list.


### PR DESCRIPTION
[Consul](https://github.com/hashicorp/consul) has recently switched to using BoltDB as its backend store. It is used to store Raft logs to persist cluster state, and so far we love it! It has enabled us to shed the pain of compiling for multiple platforms with CGO. Keep up the great work, and thank you!