### PR TITLE
Wait for pending transactions on close

### DIFF
--- a/db.go
+++ b/db.go
@@ -351,8 +351,15 @@ func (db *DB) init() error {
 // Close releases all database resources.
 // All transactions must be closed before closing the database.
 func (db *DB) Close() error {
+	db.rwlock.Lock()
+	defer db.rwlock.Unlock()
+
 	db.metalock.Lock()
 	defer db.metalock.Unlock()
+
+	db.mmaplock.RLock()
+	defer db.mmaplock.RUnlock()
+
 	return db.close()
 }
 


### PR DESCRIPTION
## Overview

This pull request fixes the `DB.Close()` function so that it waits for any open transactions to finish before closing.

Previously a close would shutdown the `DB` immediately and cause a panic in any open transactions, however, no data corruption would occur.

Fixes: https://github.com/boltdb/bolt/issues/341