### PR TITLE
Add batch size and delay docs

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -20,6 +20,9 @@ import (
 // take permanent effect only after a successful return is seen in
 // caller.
 //
+// The maximum batch size and delay can be adjusted with DB.MaxBatchSize
+// and DB.MaxBatchDelay, respectively.
+//
 // Batch is only useful when there are multiple goroutines calling it.
 func (db *DB) Batch(fn func(*Tx) error) error {
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## Overview

This commit adds documentation for batch size and delay to the `DB.Batch()` call. Previously there was no reference to these properties from the `Batch()` call so it was nearly impossible for anyone to know to adjust these settings.

Thanks to Kelly Sommers (@kellabyte) for bringing the doc issue to my attention. :tada: :tada: :tada: 