### PR TITLE
Faster freelist updates

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -48,15 +48,14 @@ func (f *freelist) pending_count() int {
 
 // all returns a list of all free ids and all pending ids in one sorted list.
 func (f *freelist) all() []pgid {
-	ids := make([]pgid, len(f.ids))
-	copy(ids, f.ids)
+	m := make(pgids, 0)
 
 	for _, list := range f.pending {
-		ids = append(ids, list...)
+		m = append(m, list...)
 	}
 
-	sort.Sort(pgids(ids))
-	return ids
+	sort.Sort(m)
+	return pgids(f.ids).Merge(m)
 }
 
 // allocate returns the starting page id of a contiguous list of pages of a given size.
@@ -127,15 +126,17 @@ func (f *freelist) free(txid txid, p *page) {
 
 // release moves all page ids for a transaction id (or older) to the freelist.
 func (f *freelist) release(txid txid) {
+	m := make(pgids, 0)
 	for tid, ids := range f.pending {
 		if tid <= txid {
 			// Move transaction's pending pages to the available freelist.
 			// Don't remove from the cache since the page is still free.
-			f.ids = append(f.ids, ids...)
+			m = append(m, ids...)
 			delete(f.pending, tid)
 		}
 	}
-	sort.Sort(pgids(f.ids))
+	sort.Sort(m)
+	f.ids = pgids(f.ids).Merge(m)
 }
 
 // rollback removes the pages from a given pending tx.

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -1,6 +1,7 @@
 package bolt
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
 	"unsafe"
@@ -126,4 +127,27 @@ func TestFreelist_write(t *testing.T) {
 	if exp := []pgid{3, 11, 12, 28, 39}; !reflect.DeepEqual(exp, f2.ids) {
 		t.Fatalf("exp=%v; got=%v", exp, f2.ids)
 	}
+}
+
+func Benchmark_FreelistRelease10K(b *testing.B)    { benchmark_FreelistRelease(b, 10000) }
+func Benchmark_FreelistRelease100K(b *testing.B)   { benchmark_FreelistRelease(b, 100000) }
+func Benchmark_FreelistRelease1000K(b *testing.B)  { benchmark_FreelistRelease(b, 1000000) }
+func Benchmark_FreelistRelease10000K(b *testing.B) { benchmark_FreelistRelease(b, 10000000) }
+
+func benchmark_FreelistRelease(b *testing.B, size int) {
+	ids := randomPgids(size)
+	pending := randomPgids(len(ids) / 400)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := &freelist{ids: ids, pending: map[txid][]pgid{1: pending}}
+		f.release(1)
+	}
+}
+
+func randomPgids(n int) []pgid {
+	pgids := make([]pgid, n)
+	for i := range pgids {
+		pgids[i] = pgid(rand.Int63())
+	}
+	return pgids
 }

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -145,6 +145,7 @@ func benchmark_FreelistRelease(b *testing.B, size int) {
 }
 
 func randomPgids(n int) []pgid {
+	rand.Seed(42)
 	pgids := make([]pgid, n)
 	for i := range pgids {
 		pgids[i] = pgid(rand.Int63())

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -3,6 +3,7 @@ package bolt
 import (
 	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 	"unsafe"
 )
@@ -146,9 +147,10 @@ func benchmark_FreelistRelease(b *testing.B, size int) {
 
 func randomPgids(n int) []pgid {
 	rand.Seed(42)
-	pgids := make([]pgid, n)
+	pgids := make(pgids, n)
 	for i := range pgids {
 		pgids[i] = pgid(rand.Int63())
 	}
+	sort.Sort(pgids)
 	return pgids
 }

--- a/page.go
+++ b/page.go
@@ -142,20 +142,22 @@ func (s1 pgids) Merge(s2 pgids) pgids {
 	if len(s2) == 0 {
 		return s1
 	}
+	merged := make(pgids, 0, len(s1)+len(s2))
 	lead, follow := s1, s2
 	if s2[0] < s1[0] {
-		lead = s2
-		follow = s1
+		lead, follow = s2, s1
 	}
-	merged := make(pgids, 0, len(s1)+len(s2))
 	for len(lead) > 0 {
+		// Merge largest prefix of lead that is ahead of follow[0].
 		n := sort.Search(len(lead), func(i int) bool { return lead[i] > follow[0] })
 		merged = append(merged, lead[:n]...)
 		if n >= len(lead) {
 			break
 		}
+		// Swap lead and follow.
 		lead, follow = follow, lead[n:]
 	}
+	// Append what's left in follow.
 	merged = append(merged, follow...)
 	return merged
 }

--- a/page_test.go
+++ b/page_test.go
@@ -1,6 +1,7 @@
 package bolt
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -26,4 +27,19 @@ func TestPage_typ(t *testing.T) {
 // Ensure that the hexdump debugging function doesn't blow up.
 func TestPage_dump(t *testing.T) {
 	(&page{id: 256}).hexdump(16)
+}
+
+func TestPgids_Merge(t *testing.T) {
+	a := pgids{4, 5, 6, 10, 11, 12, 13, 27}
+	b := pgids{1, 3, 8, 9, 25, 30}
+	c := a.Merge(b)
+	if !reflect.DeepEqual(c, pgids{1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30}) {
+		t.Errorf("mismatch: %v", c)
+	}
+	a = pgids{4, 5, 6, 10, 11, 12, 13, 27, 35, 36}
+	b = pgids{8, 9, 25, 30}
+	c = a.Merge(b)
+	if !reflect.DeepEqual(c, pgids{4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30, 35, 36}) {
+		t.Errorf("mismatch: %v", c)
+	}
 }


### PR DESCRIPTION
Since freelist is kept sorted we can update it by merging the sorted pgid lists rather than appending and resorting the whole list. We have DBs in production reaching 10M pages in the freelist and about 20K pages in the pending lists. The benchmark is an attempt to prove that at these sizes the merge can be nearly 100x faster than the append/sort approach.

Append/Sort:
```
Martins-MacBook-Pro-5:bolt martin$ go test -v -bench=FreelistRelease -run None -short
seed: 56446
quick settings: count=5, items=1000, ksize=1024, vsize=1024
PASS
Benchmark_FreelistRelease10K	    1000	   1301767 ns/op
Benchmark_FreelistRelease100K	     100	  15634815 ns/op
Benchmark_FreelistRelease1000K	      10	 182048520 ns/op
Benchmark_FreelistRelease10000K	       1	2187250681 ns/op
ok  	github.com/boltdb/bolt	11.825s
```

Merge:
```
Martins-MacBook-Pro-5:bolt martin$ go test -v -bench=FreelistRelease -run None -short
seed: 27571
quick settings: count=5, items=1000, ksize=1024, vsize=1024
PASS
Benchmark_FreelistRelease10K	   30000	     50734 ns/op
Benchmark_FreelistRelease100K	    5000	    210540 ns/op
Benchmark_FreelistRelease1000K	     500	   3132026 ns/op
Benchmark_FreelistRelease10000K	      30	  37413055 ns/op
ok  	github.com/boltdb/bolt	19.631s
```

This isn't a theoretical issue, we have a production scenario with large freelists where freelist sorting is taking nearly 90% of CPU time. I suspect that slowness of the freelist updates could significantly contribute to explosive freelist growth as well if it extends transaction duration by seconds.

@benbjohnson, I'm going to test this branch in some of our production scenarios next, but I would love your thoughts on this change, in case I'm missing something. Thanks!

/cc @snormore