### PR TITLE
Fix invalid fmt.Fprintln/Errorf calls

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -344,7 +344,7 @@ func (cmd *DumpCommand) Run(args ...string) error {
 	for i, pageID := range pageIDs {
 		// Print a separator.
 		if i > 0 {
-			fmt.Fprintln(cmd.Stdout, "===============================================\n")
+			fmt.Fprintln(cmd.Stdout, "===============================================")
 		}
 
 		// Print page to stdout.
@@ -465,7 +465,7 @@ func (cmd *PageCommand) Run(args ...string) error {
 	for i, pageID := range pageIDs {
 		// Print a separator.
 		if i > 0 {
-			fmt.Fprintln(cmd.Stdout, "===============================================\n")
+			fmt.Fprintln(cmd.Stdout, "===============================================")
 		}
 
 		// Retrieve page info and page size.
@@ -917,7 +917,7 @@ func (cmd *BenchCommand) Run(args ...string) error {
 	// Write to the database.
 	var results BenchResults
 	if err := cmd.runWrites(db, options, &results); err != nil {
-		return fmt.Errorf("write: ", err)
+		return fmt.Errorf("write: %v", err)
 	}
 
 	// Read from the database.


### PR DESCRIPTION
`go vet` discovered two calls of Fprintln with trailing newline and one
Errorf call without proper format string.