### PR TITLE
no need to call Truncate and Sync if size is not changed

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -45,10 +45,10 @@ func funlock(f *os.File) error {
 }
 
 // mmap memory maps a DB's data file.
-func mmap(db *DB, sz int) error {
+func mmap(db *DB, sz int, callTruncate bool) error {
 	// Truncate and fsync to ensure file size metadata is flushed.
 	// https://github.com/boltdb/bolt/issues/284
-	if !db.NoGrowSync && !db.readOnly {
+	if callTruncate {
 		if err := db.file.Truncate(int64(sz)); err != nil {
 			return fmt.Errorf("file resize error: %s", err)
 		}

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -27,8 +27,8 @@ func funlock(f *os.File) error {
 
 // mmap memory maps a DB's data file.
 // Based on: https://github.com/edsrzf/mmap-go
-func mmap(db *DB, sz int) error {
-	if !db.readOnly {
+func mmap(db *DB, sz int, callTruncate bool) error {
+	if callTruncate {
 		// Truncate the database to the size of the mmap.
 		if err := db.file.Truncate(int64(sz)); err != nil {
 			return fmt.Errorf("truncate: %s", err)

--- a/db.go
+++ b/db.go
@@ -238,7 +238,8 @@ func (db *DB) mmap(minsz int) error {
 	}
 
 	// Memory-map the data file as a byte slice.
-	if err := mmap(db, size); err != nil {
+	callTruncate := info.Size() != int64(size) && !db.NoGrowSync && !db.readOnly
+	if err := mmap(db, size, callTruncate); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
https://github.com/boltdb/bolt/issues/284 mentions that Sync should be called on size change.
But if size is not changed, why Sync is called?
It is an issue for opening file: size is really the same.
Truncate+Sync slows Open very much: if 10 concurrent small files are opening, then speed drops from 20000open/sec to 50open/sec 
