### PR TITLE
Speedup open huge file

### DIFF
--- a/db.go
+++ b/db.go
@@ -232,9 +232,11 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 		return nil, err
 	}
 
-	// Read in the freelist.
-	db.freelist = newFreelist()
-	db.freelist.read(db.page(db.meta().freelist))
+	if !db.readOnly {
+		// Read in the freelist.
+		db.freelist = newFreelist()
+		db.freelist.read(db.page(db.meta().freelist))
+	}
 
 	// Mark the database as opened and return.
 	return db, nil

--- a/freelist.go
+++ b/freelist.go
@@ -175,7 +175,9 @@ func (f *freelist) read(p *page) {
 		copy(f.ids, ids)
 
 		// Make sure they're sorted.
-		sort.Sort(pgids(f.ids))
+		if !pgids(f.ids).isSorted() {
+			sort.Sort(pgids(f.ids))
+		}
 	}
 
 	// Rebuild the page cache.

--- a/page.go
+++ b/page.go
@@ -139,6 +139,14 @@ type pgids []pgid
 func (s pgids) Len() int           { return len(s) }
 func (s pgids) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s pgids) Less(i, j int) bool { return s[i] < s[j] }
+func (s pgids) isSorted() bool {
+	for i := len(s)-1; i > 0; i-- {
+		if s[i] < s[i-1] {
+			return false
+		}
+	}
+	return true
+}
 
 // merge returns the sorted union of a and b.
 func (a pgids) merge(b pgids) pgids {

--- a/tx.go
+++ b/tx.go
@@ -381,7 +381,7 @@ func (tx *Tx) Check() <-chan error {
 func (tx *Tx) check(ch chan error) {
 	// Check if any pages are double freed.
 	freed := make(map[pgid]bool)
-	for _, id := range tx.db.freelist.all() {
+	for _, id := range tx.db.ensureFreelist().all() {
 		if freed[id] {
 			ch <- fmt.Errorf("page %d: already freed", id)
 		}


### PR DESCRIPTION
- use real set for freelist.cache
  map([pgids]struct{}) - is a real set structure, cause struct{} doesn't consume memory
- sort freelist.ids only if they aren't sorted
- do not read freelist if database opened in readonly mode
