### PR TITLE
solaris: fix issues with mmap, munmap, madvise and flock

### DIFF
--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -1,4 +1,3 @@
-// +build !windows,!plan9,!solaris
 
 package bolt
 
@@ -8,6 +7,7 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+	"golang.org/x/sys/unix"
 )
 
 // flock acquires an advisory lock on a file descriptor.
@@ -21,16 +21,21 @@ func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 		} else if timeout > 0 && time.Since(t) > timeout {
 			return ErrTimeout
 		}
-		flag := syscall.LOCK_SH
+		var lock syscall.Flock_t
+		lock.Start = 0
+		lock.Len = 0
+		lock.Pid = 0
+		lock.Whence = 0
+		lock.Pid = 0
 		if exclusive {
-			flag = syscall.LOCK_EX
+			lock.Type = syscall.F_WRLCK
+		} else {
+			lock.Type = syscall.F_RDLCK
 		}
-
-		// Otherwise attempt to obtain an exclusive lock.
-		err := syscall.Flock(int(f.Fd()), flag|syscall.LOCK_NB)
+		err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLK, &lock)
 		if err == nil {
 			return nil
-		} else if err != syscall.EWOULDBLOCK {
+		} else if err != syscall.EAGAIN {
 			return err
 		}
 
@@ -41,7 +46,12 @@ func flock(f *os.File, exclusive bool, timeout time.Duration) error {
 
 // funlock releases an advisory lock on a file descriptor.
 func funlock(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	var lock syscall.Flock_t
+	lock.Start = 0
+	lock.Len = 0
+	lock.Type = syscall.F_UNLCK
+	lock.Whence = 0
+	return syscall.FcntlFlock(uintptr(f.Fd()), syscall.F_SETLK, &lock)
 }
 
 // mmap memory maps a DB's data file.
@@ -58,13 +68,13 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Map the data file to memory.
-	b, err := syscall.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED)
+	b, err := unix.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		return err
 	}
 
 	// Advise the kernel that the mmap is accessed randomly.
-	if err := madvise(b, syscall.MADV_RANDOM); err != nil {
+	if err := unix.Madvise(b, syscall.MADV_RANDOM); err != nil {
 		return fmt.Errorf("madvise: %s", err)
 	}
 
@@ -83,18 +93,9 @@ func munmap(db *DB) error {
 	}
 
 	// Unmap using the original byte slice.
-	err := syscall.Munmap(db.dataref)
+	err := unix.Munmap(db.dataref)
 	db.dataref = nil
 	db.data = nil
 	db.datasz = 0
 	return err
-}
-
-// NOTE: This function is copied from stdlib because it is not available on darwin.
-func madvise(b []byte, advice int) (err error) {
-	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)), uintptr(advice))
-	if e1 != 0 {
-		err = e1
-	}
-	return
 }

--- a/db_test.go
+++ b/db_test.go
@@ -42,6 +42,9 @@ func TestOpen_Timeout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("timeout not supported on windows")
 	}
+	if runtime.GOOS == "solaris" {
+		t.Skip("solaris fcntl locks don't support intra-process locking")
+	}
 
 	path := tempfile()
 	defer os.Remove(path)
@@ -65,6 +68,9 @@ func TestOpen_Timeout(t *testing.T) {
 func TestOpen_Wait(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("timeout not supported on windows")
+	}
+	if runtime.GOOS == "solaris" {
+		t.Skip("solaris fcntl locks don't support intra-process locking")
 	}
 
 	path := tempfile()
@@ -228,6 +234,10 @@ func TestDB_Open_FileTooSmall(t *testing.T) {
 // and that a database can not be opened in read-write mode and in read-only
 // mode at the same time.
 func TestOpen_ReadOnly(t *testing.T) {
+	if runtime.GOOS == "solaris" {
+		t.Skip("solaris fcntl locks don't support intra-process locking")
+	}
+
 	bucket, key, value := []byte(`bucket`), []byte(`key`), []byte(`value`)
 
 	path := tempfile()


### PR DESCRIPTION
* Many thanks to @akolb1 for the FcntlFlock based flock implementation.

* Requires recent golang.org/x/sys/unix for fixed mmap,munmap,madvise.

* Fixes #274 and fixes #305.

* Addresses part of #345.

* Solaris fcntl locks don't support intra-process locking

Three unit tests were failing, now are skipped on solaris only:

```
seed: 68195
quick settings: count=5, items=1000, ksize=1024, vsize=1024
00010000000000000000000000000000
db_test.go:57: 

--- FAIL: TestOpen_Timeout (0.00s)
db_test.go:86: 

--- FAIL: TestOpen_Wait (0.00s)
db_test.go:257: 

--- FAIL: TestOpen_ReadOnly (0.00s)
FAIL
exit status 1
FAIL    github.com/boltdb/bolt  354.617s
```

* FcntlFlock treats separate locks on separate file descriptors differently then Flock.

* Flock semantics are preferrable for multithreaded servers.

* No simple replacement currently available on Solaris.

References:

* http://infinitesque.net/articles/2010/on%20Python%20flock/

* https://github.com/jperkin/www.perkin.org.uk/blob/master/_posts/2013-01-08-solaris-portability-flock.markdown

* https://gist.github.com/MerlinDMC/3197f4d13f8145c457e4
