### PR TITLE
Release read-write Tx after close

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -236,7 +236,8 @@ func (tx *Tx) close() {
 		var freelistPendingN = tx.db.freelist.pending_count()
 		var freelistAlloc = tx.db.freelist.size()
 
-		// Remove writer lock.
+		// Remove transaction ref & writer lock.
+		tx.db.rwtx = nil
 		tx.db.rwlock.Unlock()
 
 		// Merge statistics.
@@ -250,7 +251,12 @@ func (tx *Tx) close() {
 	} else {
 		tx.db.removeTx(tx)
 	}
+
+	// Clear all references.
 	tx.db = nil
+	tx.meta = nil
+	tx.root = Bucket{tx: tx}
+	tx.pages = nil
 }
 
 // Copy writes the entire database to a writer.


### PR DESCRIPTION
## Overview

This pull request removes references to the last write transaction and and its dirty pages after the transaction has been closed. This bug did not affect the safety of the data, however, it would cause dirty pages to linger in-memory until the next write transaction began.