### PR TITLE
Add arm64 build tag

### DIFF
--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -1,3 +1,4 @@
+// +build go1.5
 package bolt
 
 // maxMapSize represents the largest mmap size supported by Bolt.


### PR DESCRIPTION
## Overview

This commit adds a build tag on bolt_arm64.go to prevent compile errors under Go 1.4. These errors occur because Go 1.4 does not recognize arm64 as a GOARCH.

Fixes #416.