### PR TITLE
Revert arm64 change

### DIFF
--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -1,7 +1,0 @@
-package bolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF


### PR DESCRIPTION
## Overview

This pull request removes the arm64 change because it caused issues with Go 1.4.

Fixes #416.