### PR TITLE
windows: implement file locking

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -8,6 +8,38 @@ import (
 	"unsafe"
 )
 
+// LockFileEx code derived from golang build filemutex_windows.go @ v1.5.1
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+	flagLockExclusive       = 2
+	flagLockFailImmediately = 1
+
+	// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+	errLockViolation syscall.Errno = 0x21
+)
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procLockFileEx.Call(uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r, _, err := procUnlockFileEx.Call(uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)), 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
 var odirect int
 
 // fdatasync flushes written data to a file descriptor.
@@ -16,13 +48,37 @@ func fdatasync(db *DB) error {
 }
 
 // flock acquires an advisory lock on a file descriptor.
-func flock(f *os.File, _ bool, _ time.Duration) error {
-	return nil
+func flock(f *os.File, exclusive bool, timeout time.Duration) error {
+	var t time.Time
+	for {
+		// If we're beyond our timeout then return an error.
+		// This can only occur after we've attempted a flock once.
+		if t.IsZero() {
+			t = time.Now()
+		} else if timeout > 0 && time.Since(t) > timeout {
+			return ErrTimeout
+		}
+
+		var flag uint32 = flagLockFailImmediately
+		if exclusive {
+			flag |= flagLockExclusive
+		}
+
+		err := lockFileEx(syscall.Handle(f.Fd()), flag, 0, 1, 0, &syscall.Overlapped{})
+		if err == nil {
+			return nil
+		} else if err != errLockViolation {
+			return err
+		}
+
+		// Wait for a bit and try again.
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // funlock releases an advisory lock on a file descriptor.
 func funlock(f *os.File) error {
-	return nil
+	return unlockFileEx(syscall.Handle(f.Fd()), 0, 1, 0, &syscall.Overlapped{})
 }
 
 // mmap memory maps a DB's data file.

--- a/db_test.go
+++ b/db_test.go
@@ -39,9 +39,6 @@ func TestOpen(t *testing.T) {
 
 // Ensure that opening an already open database file will timeout.
 func TestOpen_Timeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("timeout not supported on windows")
-	}
 	if runtime.GOOS == "solaris" {
 		t.Skip("solaris fcntl locks don't support intra-process locking")
 	}
@@ -66,9 +63,6 @@ func TestOpen_Timeout(t *testing.T) {
 
 // Ensure that opening an already open database file will wait until its closed.
 func TestOpen_Wait(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("timeout not supported on windows")
-	}
 	if runtime.GOOS == "solaris" {
 		t.Skip("solaris fcntl locks don't support intra-process locking")
 	}


### PR DESCRIPTION
I added file locking for Windows. Some links to reference constant sources are included.

Tested manually using an example program that simply opens a DB and waits for signal, against Windows XP (sadly, my target platform). According to MSDN this should work on future platforms also, see referenced documentation.

The timeout support was derived from flock_unix.go.