### PR TITLE
Add two little projects to README project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,5 +617,9 @@ Below is a list of public, open source projects that use Bolt:
 * [Consul](https://github.com/hashicorp/consul) - Consul is service discovery and configuration made easy. Distributed, highly available, and datacenter-aware.
 * [Kala](https://github.com/ajvb/kala) - Kala is a modern job scheduler optimized to run on a single node. It is persistant, JSON over HTTP API, ISO 8601 duration notation, and dependent jobs.
 * [drive](https://github.com/odeke-em/drive) - drive is an unofficial Google Drive command line client for \*NIX operating systems.
+* [stow](https://github.com/djherbis/stow) -  a persistence manager for objects
+  backed by boltdb.
+* [buckets](https://github.com/joyrexus/buckets) - a bolt wrapper streamlining
+  simple tx and key scans.
 
 If you are using Bolt in a project please send a pull request to add it to the list.


### PR DESCRIPTION
So, [stow](https://github.com/djherbis/stow) is just a little utility to simplify de/encoding values and [buckets](https://github.com/joyrexus/buckets) is a tiny wrapper/extension, but some might find 'em handy for the particular use cases they're targeting.

I considered adding [simplebolt](https://github.com/xyproto/simplebolt) as well, but that might qualify as more of a personal experiment than something designed for other users.  Not sure.  (I guess there are tests and a license.)

Feel free to close/reject this pull request if you'd prefer a separate sub-heading in the README for utilities/extensions/experiments, restricting the current list to notable public/opensource projects?  Or perhaps a project wiki page, organized by broad categories?