### PR TITLE
Add support for arm64

### DIFF
--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -1,0 +1,9 @@
+// +build arm64
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0x7FFFFFFF


### PR DESCRIPTION
Added build tag for arm64, so we won't get any errors on other
platforms with go 1.4.x.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>