### PR TITLE
In TestBucket_Delete_FreelistOverflow, use Cursor.Delete to remove records.

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -253,7 +253,7 @@ func TestBucket_Delete_FreelistOverflow(t *testing.T) {
 		b := tx.Bucket([]byte("0"))
 		c := b.Cursor()
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			b.Delete(k)
+			c.Delete()
 		}
 		return nil
 	})


### PR DESCRIPTION
When removing all the keys from the bucket, use Cursor.Delete directly, which
avoids a seek through the bucket to find the element to delete.  This knocks
1/5 of the time off my laptop when running this test while not reducing the
amount of overflow pages cleared out of the free list.