### PR TITLE
bucket: document Put() value must remain valid for the transaction

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -270,6 +270,7 @@ func (b *Bucket) Get(key []byte) []byte {
 
 // Put sets the value for a key in the bucket.
 // If the key exist then its previous value will be overwritten.
+// Supplied value must remain valid for the life of the transaction.
 // Returns an error if the bucket was created from a read-only transaction, if the key is blank, if the key is too large, or if the value is too large.
 func (b *Bucket) Put(key []byte, value []byte) error {
 	if b.tx.db == nil {


### PR DESCRIPTION
Issue #324

I have been bitten by this too. Let's try to move forward on the documentation (or implementation).