### PR TITLE
README: mention the memory map consumes a lot of address space

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,9 @@ Here are a few things to note when evaluating and using Bolt:
   can in memory and will release memory as needed to other processes. This means
   that Bolt can show very high memory usage when working with large databases.
   However, this is expected and the OS will release memory as needed. Bolt can
-  handle databases much larger than the available physical RAM.
+  handle databases much larger than the available physical RAM, provided its
+  memory-map fits in the process virtual address space. It may be problematic
+  on 32-bits systems.
 
 * The data structures in the Bolt database are memory mapped so the data file
   will be endian specific. This means that you cannot copy a Bolt file from a


### PR DESCRIPTION
I have been bitten by this when running a simple application on a
Raspberry Pi 2. It had 3 stores: two 512M stores and one 128M. The
application refused to start the moment the first index grew from 512M
to 1G.

Bolt is really nice but it is easy to overlook this limitation,
especially with the note about supporting stores much larger than
*physical* memory.