### PR TITLE
Lower MaxValue to 2GB

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -11,7 +11,7 @@ const (
 	MaxKeySize = 32768
 
 	// MaxValueSize is the maximum length of a value, in bytes.
-	MaxValueSize = 4294967295
+	MaxValueSize = (1 << 31) - 2
 )
 
 const (


### PR DESCRIPTION
## Overview

This pull request changes the maximum value size from 4GB to 2GB so that tests can run on 32-bit machines. There's really no reason to write a 2GB+ value to Bolt. Bolt is not terribly efficient for large values.