### PR TITLE
add WriteToFlag to Tx

### DIFF
--- a/bolt_linux.go
+++ b/bolt_linux.go
@@ -4,8 +4,6 @@ import (
 	"syscall"
 )
 
-var odirect = syscall.O_DIRECT
-
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
 	return syscall.Fdatasync(int(db.file.Fd()))

--- a/bolt_openbsd.go
+++ b/bolt_openbsd.go
@@ -11,8 +11,6 @@ const (
 	msInvalidate             // invalidate cached data
 )
 
-var odirect int
-
 func msync(db *DB) error {
 	_, _, errno := syscall.Syscall(syscall.SYS_MSYNC, uintptr(unsafe.Pointer(db.data)), uintptr(db.datasz), msInvalidate)
 	if errno != 0 {

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -40,8 +40,6 @@ func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *sysc
 	return nil
 }
 
-var odirect int
-
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
 	return db.file.Sync()


### PR DESCRIPTION
For in memory workload, it does not make sense to use
o_direct to copy the file. Adding a option to clear out
o_direct and for other future cases.