### PR TITLE
Add MmapFlags option for MAP_POPULATE (unix)

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -58,7 +58,7 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Map the data file to memory.
-	b, err := syscall.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED)
+	b, err := syscall.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
 	if err != nil {
 		return err
 	}

--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -1,4 +1,3 @@
-
 package bolt
 
 import (
@@ -7,6 +6,7 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -68,7 +68,7 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Map the data file to memory.
-	b, err := unix.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED)
+	b, err := unix.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
 	if err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -63,6 +63,10 @@ type DB struct {
 	// https://github.com/boltdb/bolt/issues/284
 	NoGrowSync bool
 
+	// If you want to read the entire database fast, you can set MmapFlag to
+	// syscall.MAP_POPULATE on Linux 2.6.23+ for sequential read-ahead.
+	MmapFlags int
+
 	// MaxBatchSize is the maximum size of a batch. Default value is
 	// copied from DefaultMaxBatchSize in Open.
 	//
@@ -136,6 +140,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 		options = DefaultOptions
 	}
 	db.NoGrowSync = options.NoGrowSync
+	db.MmapFlags = options.MmapFlags
 
 	// Set default values for later DB operations.
 	db.MaxBatchSize = DefaultMaxBatchSize
@@ -672,6 +677,9 @@ type Options struct {
 	// Open database in read-only mode. Uses flock(..., LOCK_SH |LOCK_NB) to
 	// grab a shared lock (UNIX).
 	ReadOnly bool
+
+	// Sets the DB.MmapFlags flag before memory mapping the file.
+	MmapFlags int
 }
 
 // DefaultOptions represent the options used if nil options are passed into Open().


### PR DESCRIPTION
/cc @xiang90 

This adds MmapFlags to set syscall.MAP_POPULATE in Linux 2.6.23+.
If true, it would do the sequential read-ahead, as discussed in [1].

Xiang helped me on this PR. I benchmarked the READ performance and with `MAP_POPULATE` flag,
its read performance increased. I did:

1. Generated random data of 2GB.
2. Clean up page cache `echo "echo 1 > /proc/sys/vm/drop_caches" | sudo sh`
3. Read **with** and **without** `MAP_POPULATE` and compare two results [2].

<br>
Results

- SSD, Ubuntu, Intel(R) Core(TM) i7-4910MQ CPU @ 2.90GHz, go version go1.5.1 linux/amd64, Linux kernel version: 3.16.0-52-generic

For 2GB, read takes 8 seconds without `MAP_POPULATE`, 4 seconds WITH `MAP_POPULATE`.

<br>
- HDD, 1 vCPU, 3.75 GB Memory, Google Cloud, Intel(R) Xeon(R) CPU @ 2.30GHz, go version go1.5.1 linux/amd64, Linux kernel version: 3.16.0-0.bpo.4-amd64

For 2GB, read takes 2 minutes 10 seconds seconds without `MAP_POPULATE`, 8 seconds WITH `MAP_POPULATE`.

<br>
And I added `MAP_POPULATE`  and WITHOUT cleaning up the page cache in a separate machine. This takes about the same as the first test case where we cleaned up page cache.

---

[1]:

https://github.com/coreos/etcd/issues/3786

[2]:

```go
package main

import (
	"fmt"
	"time"
	"syscall"

	"github.com/boltdb/bolt"
)

const (
	dbPath     = "fake.db"
	bucketName = "fake-bucket"
	writable   = false
)

func main() {
	st := time.Now()
	// Open the dbPath data file in your current directory.
	// It will be created if it doesn't exist.
        // db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Minute, ReadOnly: true})
	db, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 5 * time.Minute, ReadOnly: true, MmapFlags: syscall.MAP_POPULATE})
	if err != nil {
		panic(err)
	}
	defer db.Close()

	tx, err := db.Begin(writable)
	if err != nil {
		panic(err)
	}
	defer tx.Rollback()

	bk := tx.Bucket([]byte(bucketName))
	c := bk.Cursor()

	for k, v := c.First(); k != nil; k, v = c.Next() {
		// fmt.Printf("%s ---> %s.\n", k, v)
		_ = k
		_ = v
	}
	fmt.Println("took:", time.Since(st))
}
```

