### PR TITLE
Apply some changes suggested by golint

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -167,9 +167,8 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 	if bytes.Equal(key, k) {
 		if (flags & bucketLeafFlag) != 0 {
 			return nil, ErrBucketExists
-		} else {
-			return nil, ErrIncompatibleValue
 		}
+		return nil, ErrIncompatibleValue
 	}
 
 	// Create empty, inline bucket.
@@ -365,13 +364,13 @@ func (b *Bucket) ForEach(fn func(k, v []byte) error) error {
 	return nil
 }
 
-// Stat returns stats on a bucket.
+// Stats returns stats on a bucket.
 func (b *Bucket) Stats() BucketStats {
 	var s, subStats BucketStats
 	pageSize := b.tx.db.pageSize
-	s.BucketN += 1
+	s.BucketN++
 	if b.root == 0 {
-		s.InlineBucketN += 1
+		s.InlineBucketN++
 	}
 	b.forEachPage(func(p *page, depth int) {
 		if (p.flags & leafPageFlag) != 0 {
@@ -721,6 +720,8 @@ type BucketStats struct {
 	InlineBucketInuse int // bytes used for inlined buckets (also accounted for in LeafInuse)
 }
 
+// Add adds the stats from other bucket into the bucket. Use it to aggregate
+// statistics of multiple buckets.
 func (s *BucketStats) Add(other BucketStats) {
 	s.BranchPageN += other.BranchPageN
 	s.BranchOverflowN += other.BranchOverflowN

--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -717,7 +717,7 @@ func (cmd *PagesCommand) Run(args ...string) error {
 			fmt.Fprintf(cmd.Stdout, "%-8d %-10s %-6s %-6s\n", p.ID, p.Type, count, overflow)
 
 			// Move to the next non-overflow page.
-			id += 1
+			id++
 			if p.Type != "free" {
 				id += p.OverflowCount
 			}
@@ -790,7 +790,7 @@ func (cmd *StatsCommand) Run(args ...string) error {
 		if err := tx.ForEach(func(name []byte, b *bolt.Bucket) error {
 			if bytes.HasPrefix(name, []byte(prefix)) {
 				s.Add(b.Stats())
-				count += 1
+				count++
 			}
 			return nil
 		}); err != nil {
@@ -1292,7 +1292,7 @@ type BenchResults struct {
 	ReadDuration  time.Duration
 }
 
-// Returns the duration for a single write operation.
+// WriteOpDuration returns the duration for a single write operation.
 func (r *BenchResults) WriteOpDuration() time.Duration {
 	if r.WriteOps == 0 {
 		return 0
@@ -1300,7 +1300,7 @@ func (r *BenchResults) WriteOpDuration() time.Duration {
 	return r.WriteDuration / time.Duration(r.WriteOps)
 }
 
-// Returns average number of write operations that can be performed per second.
+// WriteOpsPerSecond returns average number of write operations that can be performed per second.
 func (r *BenchResults) WriteOpsPerSecond() int {
 	var op = r.WriteOpDuration()
 	if op == 0 {
@@ -1309,7 +1309,7 @@ func (r *BenchResults) WriteOpsPerSecond() int {
 	return int(time.Second) / int(op)
 }
 
-// Returns the duration for a single read operation.
+// ReadOpDuration returns the duration for a single read operation.
 func (r *BenchResults) ReadOpDuration() time.Duration {
 	if r.ReadOps == 0 {
 		return 0
@@ -1317,7 +1317,7 @@ func (r *BenchResults) ReadOpDuration() time.Duration {
 	return r.ReadDuration / time.Duration(r.ReadOps)
 }
 
-// Returns average number of read operations that can be performed per second.
+// ReadOpsPerSecond returns average number of read operations that can be performed per second.
 func (r *BenchResults) ReadOpsPerSecond() int {
 	var op = r.ReadOpDuration()
 	if op == 0 {
@@ -1326,6 +1326,7 @@ func (r *BenchResults) ReadOpsPerSecond() int {
 	return int(time.Second) / int(op)
 }
 
+// PageError represents a page error.
 type PageError struct {
 	ID  int
 	Err error

--- a/db.go
+++ b/db.go
@@ -608,7 +608,7 @@ func (db *DB) Stats() Stats {
 	return db.stats
 }
 
-// This is for internal access to the raw data bytes from the C cursor, use
+// Info is for internal access to the raw data bytes from the C cursor, use
 // carefully, or not at all.
 func (db *DB) Info() *Info {
 	return &Info{uintptr(unsafe.Pointer(&db.data[0])), db.pageSize}
@@ -660,6 +660,8 @@ func (db *DB) allocate(count int) (*page, error) {
 	return p, nil
 }
 
+// IsReadOnly returns a boolean indicating whether the DB is read-only. When
+// true, db.Update() and db.Begin(true) return ErrDatabaseReadOnly immediately.
 func (db *DB) IsReadOnly() bool {
 	return db.readOnly
 }
@@ -725,6 +727,7 @@ func (s *Stats) add(other *Stats) {
 	s.TxStats.add(&other.TxStats)
 }
 
+// Info holds raw data bytes from the C cursor, use carefully, or not at all.
 type Info struct {
 	Data     uintptr
 	PageSize int

--- a/freelist.go
+++ b/freelist.go
@@ -29,16 +29,16 @@ func (f *freelist) size() int {
 
 // count returns count of pages on the freelist
 func (f *freelist) count() int {
-	return f.free_count() + f.pending_count()
+	return f.freeCount() + f.pendingCount()
 }
 
-// free_count returns count of free pages
-func (f *freelist) free_count() int {
+// freeCount returns count of free pages
+func (f *freelist) freeCount() int {
 	return len(f.ids)
 }
 
-// pending_count returns count of pending pages
-func (f *freelist) pending_count() int {
+// pendingCount returns count of pending pages
+func (f *freelist) pendingCount() int {
 	var count int
 	for _, list := range f.pending {
 		count += len(list)

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -130,12 +130,12 @@ func TestFreelist_write(t *testing.T) {
 	}
 }
 
-func Benchmark_FreelistRelease10K(b *testing.B)    { benchmark_FreelistRelease(b, 10000) }
-func Benchmark_FreelistRelease100K(b *testing.B)   { benchmark_FreelistRelease(b, 100000) }
-func Benchmark_FreelistRelease1000K(b *testing.B)  { benchmark_FreelistRelease(b, 1000000) }
-func Benchmark_FreelistRelease10000K(b *testing.B) { benchmark_FreelistRelease(b, 10000000) }
+func Benchmark_FreelistRelease10K(b *testing.B)    { benchmarkFreelistRelease(b, 10000) }
+func Benchmark_FreelistRelease100K(b *testing.B)   { benchmarkFreelistRelease(b, 100000) }
+func Benchmark_FreelistRelease1000K(b *testing.B)  { benchmarkFreelistRelease(b, 1000000) }
+func Benchmark_FreelistRelease10000K(b *testing.B) { benchmarkFreelistRelease(b, 10000000) }
 
-func benchmark_FreelistRelease(b *testing.B, size int) {
+func benchmarkFreelistRelease(b *testing.B, size int) {
 	ids := randomPgids(size)
 	pending := randomPgids(len(ids) / 400)
 	b.ResetTimer()

--- a/tx.go
+++ b/tx.go
@@ -243,8 +243,8 @@ func (tx *Tx) close() {
 	}
 	if tx.writable {
 		// Grab freelist stats.
-		var freelistFreeN = tx.db.freelist.free_count()
-		var freelistPendingN = tx.db.freelist.pending_count()
+		var freelistFreeN = tx.db.freelist.freeCount()
+		var freelistPendingN = tx.db.freelist.pendingCount()
 		var freelistAlloc = tx.db.freelist.size()
 
 		// Remove transaction ref & writer lock.


### PR DESCRIPTION
Not changed:

```
$ golint ./...
bucket.go:77:25: exported method Root returns unexported type bolt.pgid, which can be annoying to use
page.go:138:1: receiver name a should be consistent with previous receiver name s for pgids
cmd/bolt/main.go:1354:41: exported func ReadPage returns unexported type *main.page, which can be annoying to use
```

I think the `bucket.Root()` method should probably have a different signature, but it was added over a year ago and I wonder how many people we'd be breaking. It's not used in the current code base.

The receiver name in `page.go:138:1` seems just fine in its context, and `cmd/bolt/main.go:1354:41` is not a big deal as `cmd/bolt` is not meant to be imported (but we could make functions there unexported anyway if wanted).

I'm also not changing tests and benchmark function names that have underscores, but we could as well.

Looking forward for some feedback on these changes :smile: 
