### PR TITLE
Add bucket check to db.View in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ iteration over these keys extremely fast. To iterate over keys we'll use a
 
 ```go
 db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
 	b := tx.Bucket([]byte("MyBucket"))
+
 	c := b.Cursor()
 
 	for k, v := c.First(); k != nil; k, v = c.Next() {
@@ -389,6 +391,7 @@ To iterate over a key prefix, you can combine `Seek()` and `bytes.HasPrefix()`:
 
 ```go
 db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
 	c := tx.Bucket([]byte("MyBucket")).Cursor()
 
 	prefix := []byte("1234")
@@ -408,7 +411,7 @@ date range like this:
 
 ```go
 db.View(func(tx *bolt.Tx) error {
-	// Assume our events bucket has RFC3339 encoded time keys.
+	// Assume our events bucket exists and has RFC3339 encoded time keys.
 	c := tx.Bucket([]byte("Events")).Cursor()
 
 	// Our time range spans the 90's decade.
@@ -432,7 +435,9 @@ all the keys in a bucket:
 
 ```go
 db.View(func(tx *bolt.Tx) error {
+	// Assume bucket exists and has keys
 	b := tx.Bucket([]byte("MyBucket"))
+	
 	b.ForEach(func(k, v []byte) error {
 		fmt.Printf("key=%s, value=%s\n", k, v)
 		return nil


### PR DESCRIPTION
Add check if bucket exists before use in examples of db.View in readme.md code examples. This check prevents a runtime panic when `db.View()` uses the bucket when nil e.g. `b.Cursor()`.

Since the readme is the most used guide by beginners, this would help avoiding this common learner panic::

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x8 pc=0x4012bf]

goroutine 1 [running]:
main.main.func1(0xc82007c000, 0x0, 0x0)
	/home/chief/go/src/bitbucket.org/etelej/appx/main.go:21 +0x8f
github.com/boltdb/bolt.(*DB).View(0xc820060820, 0x57d308, 0x0, 0x0)
	/home/chief/go/src/github.com/boltdb/bolt/db.go:583 +0xb9
main.main()
	/home/chief/go/src/bitbucket.org/etelej/appx/main.go:26 +0x177
exit status 2
```