### PR TITLE
Use sync.Pool for small pages in db.allocate

### DIFF
--- a/db.go
+++ b/db.go
@@ -36,6 +36,9 @@ const (
 	DefaultAllocSize         = 16 * 1024 * 1024
 )
 
+// default page size for db is set to the OS page size.
+var defaultPageSize = os.Getpagesize()
+
 // DB represents a collection of buckets persisted to a file on disk.
 // All data access is performed through transactions which can be obtained through the DB.
 // All the functions on DB will return a ErrDatabaseNotOpen if accessed before Open() is called.
@@ -320,7 +323,7 @@ func (db *DB) mmapSize(size int) (int, error) {
 // init creates a new database file and initializes its meta pages.
 func (db *DB) init() error {
 	// Set the page size to the OS page size.
-	db.pageSize = os.Getpagesize()
+	db.pageSize = defaultPageSize
 
 	// Create two meta pages on a buffer.
 	buf := make([]byte, db.pageSize*4)
@@ -779,10 +782,21 @@ func (db *DB) meta() *meta {
 	return db.meta1
 }
 
+var pagePool = sync.Pool{
+	New: func() interface{} {
+		return make([]byte, defaultPageSize)
+	},
+}
+
 // allocate returns a contiguous block of memory starting at a given page.
 func (db *DB) allocate(count int) (*page, error) {
 	// Allocate a temporary buffer for the page.
-	buf := make([]byte, count*db.pageSize)
+	var buf []byte
+	if count == 1 && db.pageSize == defaultPageSize {
+		buf = pagePool.Get().([]byte)
+	} else {
+		buf = make([]byte, count*db.pageSize)
+	}
 	p := (*page)(unsafe.Pointer(&buf[0]))
 	p.overflow = uint32(count - 1)
 


### PR DESCRIPTION
I used #409 as a base for this patch. I decided to treat only `count == 1` as a small page. Also pool is used only for databases with `pageSize == os.Getpagesize`. I think that it's possible to create dynamic pool for each `pageSize` in system, but it's not worth it.
Benchmark results:
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkDBBatchAutomatic-4        2552625       2485200       -2.64%
BenchmarkDBBatchSingle-4           59632698      50757603      -14.88%
BenchmarkDBBatchManual10x100-4     2564789       2452735       -4.37%

benchmark                          old allocs     new allocs     delta
BenchmarkDBBatchAutomatic-4        10199          10202          +0.03%
BenchmarkDBBatchSingle-4           56642          56653          +0.02%
BenchmarkDBBatchManual10x100-4     5986           5995           +0.15%

benchmark                          old bytes     new bytes     delta
BenchmarkDBBatchAutomatic-4        433587        382462        -11.79%
BenchmarkDBBatchSingle-4           32504533      16308931      -49.83%
BenchmarkDBBatchManual10x100-4     1362370       881765        -35.28%
```