### PR TITLE
Use pointers instead of structs for inodes.

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -345,7 +345,7 @@ func (c *Cursor) keyValue() ([]byte, []byte, uint32) {
 
 	// Retrieve value from node.
 	if ref.node != nil {
-		inode := &ref.node.inodes[ref.index]
+		inode := ref.node.inodes[ref.index]
 		return inode.key, inode.value, inode.flags
 	}
 

--- a/node.go
+++ b/node.go
@@ -40,7 +40,7 @@ func (n *node) minKeys() int {
 func (n *node) size() int {
 	sz, elsz := pageHeaderSize, n.pageElementSize()
 	for i := 0; i < len(n.inodes); i++ {
-		item := &n.inodes[i]
+		item := n.inodes[i]
 		sz += elsz + len(item.key) + len(item.value)
 	}
 	return sz
@@ -52,7 +52,7 @@ func (n *node) size() int {
 func (n *node) sizeLessThan(v int) bool {
 	sz, elsz := pageHeaderSize, n.pageElementSize()
 	for i := 0; i < len(n.inodes); i++ {
-		item := &n.inodes[i]
+		item := n.inodes[i]
 		sz += elsz + len(item.key) + len(item.value)
 		if sz >= v {
 			return false
@@ -128,11 +128,12 @@ func (n *node) put(oldKey, newKey, value []byte, pgid pgid, flags uint32) {
 	// Add capacity and shift nodes if we don't have an exact match and need to insert.
 	exact := (len(n.inodes) > 0 && index < len(n.inodes) && bytes.Equal(n.inodes[index].key, oldKey))
 	if !exact {
-		n.inodes = append(n.inodes, inode{})
+		n.inodes = append(n.inodes, nil)
 		copy(n.inodes[index+1:], n.inodes[index:])
+		n.inodes[index] = &inode{}
 	}
 
-	inode := &n.inodes[index]
+	inode := n.inodes[index]
 	inode.flags = flags
 	inode.key = newKey
 	inode.value = value
@@ -162,9 +163,12 @@ func (n *node) read(p *page) {
 	n.pgid = p.id
 	n.isLeaf = ((p.flags & leafPageFlag) != 0)
 	n.inodes = make(inodes, int(p.count))
+	for i := range n.inodes {
+		n.inodes[i] = &inode{}
+	}
 
 	for i := 0; i < int(p.count); i++ {
-		inode := &n.inodes[i]
+		inode := n.inodes[i]
 		if n.isLeaf {
 			elem := p.leafPageElement(uint16(i))
 			inode.flags = elem.flags
@@ -486,7 +490,7 @@ func (n *node) rebalance() {
 				child.parent = n
 				child.parent.children = append(child.parent.children, child)
 			}
-			n.inodes = append(n.inodes, inode{})
+			n.inodes = append(n.inodes, nil)
 			copy(n.inodes[1:], n.inodes)
 			n.inodes[0] = target.inodes[len(target.inodes)-1]
 			target.inodes = target.inodes[:len(target.inodes)-1]
@@ -561,7 +565,7 @@ func (n *node) dereference() {
 	}
 
 	for i := range n.inodes {
-		inode := &n.inodes[i]
+		inode := n.inodes[i]
 
 		key := make([]byte, len(inode.key))
 		copy(key, inode.key)
@@ -633,4 +637,4 @@ type inode struct {
 	value []byte
 }
 
-type inodes []inode
+type inodes []*inode

--- a/node_test.go
+++ b/node_test.go
@@ -16,6 +16,7 @@ func TestNode_put(t *testing.T) {
 	if len(n.inodes) != 3 {
 		t.Fatalf("exp=3; got=%d", len(n.inodes))
 	}
+
 	if k, v := n.inodes[0].key, n.inodes[0].value; string(k) != "bar" || string(v) != "1" {
 		t.Fatalf("exp=<bar,1>; got=<%s,%s>", k, v)
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -16,7 +16,6 @@ func TestNode_put(t *testing.T) {
 	if len(n.inodes) != 3 {
 		t.Fatalf("exp=3; got=%d", len(n.inodes))
 	}
-
 	if k, v := n.inodes[0].key, n.inodes[0].value; string(k) != "bar" || string(v) != "1" {
 		t.Fatalf("exp=<bar,1>; got=<%s,%s>", k, v)
 	}


### PR DESCRIPTION
From issue: https://github.com/boltdb/bolt/issues/509

Simple switch to use pointers to inodes instead of struct literals.  Reduces the amount of work that has to happen for insertions to a large degree.