### PR TITLE
Use tx.meta during Tx.WriteTo()

### DIFF
--- a/tx_test.go
+++ b/tx_test.go
@@ -570,7 +570,7 @@ func TestTx_CopyFile_Error_Meta(t *testing.T) {
 
 	if err := db.View(func(tx *bolt.Tx) error {
 		return tx.Copy(&failWriter{})
-	}); err == nil || err.Error() != "meta copy: error injected for tests" {
+	}); err == nil || err.Error() != "meta 0 copy: error injected for tests" {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Overview

This commit changes `Tx.WriteTo()` to use the transaction's in-memory meta page instead of copying from the disk. This is needed because the transaction uses the size from its meta page but writes the current meta page on disk which may have allocated additional pages since the transaction started.

Fixes #513

/cc @xiang90 