### PR TITLE
Add appveyor.yml.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\boltdb\bolt
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+  - go get -v -t ./...
+
+build_script:
+  - go test -v ./...


### PR DESCRIPTION
Add an initial appveryor.yml to test on AppVeyor's Windows CI.

See here for a sample run: https://ci.appveyor.com/project/MJDSys/bolt/build/2

They provide free accounts for open source software.  I signed up with no issue to test this.