### PR TITLE
Add bolt_ppc.go to compile on 32-bit PPC platforms.

### DIFF
--- a/bolt_ppc.go
+++ b/bolt_ppc.go
@@ -1,0 +1,9 @@
+// +build ppc
+
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x7FFFFFFF // 2GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF


### PR DESCRIPTION
Adding this file allowed me to compile and run bolt in Linux on my old 32-bit PPC Mac Mini.

```
$ cat /proc/cpuinfo 
processor	: 0
cpu			: 7447A, altivec supported
clock		: 1249.999995MHz
revision		: 1.2 (pvr 8003 0102)
bogomips	: 83.24

total bogomips	: 83.24
timebase		: 41620997
platform		: PowerMac
model		: PowerMac10,1
machine		: PowerMac10,1
motherboard	: PowerMac10,1 MacRISC3 Power Macintosh 
detected as	: 287 (Mac mini)
pmac flags	: 00000010
L2 cache		: 512K unified
pmac-generation	: NewWorld
Memory		: 1024 MB
```