### PR TITLE
Add note about Go RFC3339Nano sortability to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ db.View(func(tx *bolt.Tx) error {
 })
 ```
 
+Note that, while RFC3339 is sortable, the Golang implementation of RFC3339Nano does not use a fixed number of digits after the decimal point and is therefore not sortable.
+
 
 #### ForEach()
 


### PR DESCRIPTION
RFC3339 is sortable, but RFC3339Nano is not, because it does not use a fixed number of digits after the decimal.

Fixes #536 