### PR TITLE
Delay clearing db.path until just before db.close returns.

### DIFF
--- a/db.go
+++ b/db.go
@@ -94,7 +94,7 @@ type DB struct {
 	path     string
 	file     *os.File
 	lockfile *os.File // windows only
-	dataref  []byte // mmap'ed readonly, write throws SEGV
+	dataref  []byte   // mmap'ed readonly, write throws SEGV
 	data     *[maxMapSize]byte
 	datasz   int
 	filesz   int // current on disk file size
@@ -383,11 +383,10 @@ func (db *DB) close() error {
 	if !db.opened {
 		return nil
 	}
-	
+
 	db.opened = false
 
 	db.freelist = nil
-	db.path = ""
 
 	// Clear ops.
 	db.ops.writeAt = nil
@@ -414,6 +413,7 @@ func (db *DB) close() error {
 		db.file = nil
 	}
 
+	db.path = ""
 	return nil
 }
 


### PR DESCRIPTION
The Windows version of funlock needs the db.path to delete the
corresponding .lock file.

Fix for #549.