### PR TITLE
Fix issue #547 'Deleting bucket after inserting a nil value'

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -228,7 +228,7 @@ func (b *Bucket) DeleteBucket(key []byte) error {
 	// Recursively delete all child buckets.
 	child := b.Bucket(key)
 	err := child.ForEach(func(k, v []byte) error {
-		if v == nil {
+		if _, _, childFlags := child.Cursor().seek(k); (childFlags & bucketLeafFlag) != 0 {
 			if err := child.DeleteBucket(k); err != nil {
 				return fmt.Errorf("delete bucket: %s", err)
 			}


### PR DESCRIPTION
Looks like any key with a nil value would be considered as a sub
bucket, replaced the previous 'v == nil' test by a more explicit test
on flags. In the general case it should do the same (a sub-bucket does
not have a non-nil value, does it?) but it should also handle properly
the case of nil values on real keys.