### PR TITLE
Fix issue #543 'bolt bench crashes'

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1180,12 +1180,14 @@ func (cmd *BenchCommand) runReadsSequentialNested(db *bolt.DB, options *BenchOpt
 			var count int
 			var top = tx.Bucket(benchBucketName)
 			if err := top.ForEach(func(name, _ []byte) error {
-				c := top.Bucket(name).Cursor()
-				for k, v := c.First(); k != nil; k, v = c.Next() {
-					if v == nil {
-						return ErrInvalidValue
+				if b := top.Bucket(name); b != nil {
+					c := b.Cursor()
+					for k, v := c.First(); k != nil; k, v = c.Next() {
+						if v == nil {
+							return ErrInvalidValue
+						}
+						count++
 					}
-					count++
 				}
 				return nil
 			}); err != nil {


### PR DESCRIPTION
Added a test to check that bucket is actually non-nil before getting a
cursor on it. This happens when querying non-bucket entries, the
Bucket() method does not return explicit errors, so we can guess it's
probably because it's a key of the wrong type (ie: not leaf). No clear
idea wether the results in the case described '-read-mode=seq
-write-mode=rnd-nest' really do make sense, it looks like read are
zero whatsoever.
