### PR TITLE
Reduce allocations when traversing a database

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -216,6 +216,7 @@ func (b *Bucket) DeleteBucket(key []byte) error {
 	// Move cursor to correct position.
 	c := b.Cursor()
 	k, _, flags := c.seek(key)
+	defer c.Close()
 
 	// Return an error if bucket doesn't exist or is not a bucket.
 	if !bytes.Equal(key, k) {
@@ -291,6 +292,7 @@ func (b *Bucket) Put(key []byte, value []byte) error {
 
 	// Move cursor to correct position.
 	c := b.Cursor()
+	defer c.Close()
 	k, _, flags := c.seek(key)
 
 	// Return an error if there is an existing key with a bucket value.
@@ -317,6 +319,7 @@ func (b *Bucket) Delete(key []byte) error {
 
 	// Move cursor to correct position.
 	c := b.Cursor()
+	defer c.Close()
 	_, _, flags := c.seek(key)
 
 	// Return an error if there is already existing bucket value.
@@ -358,12 +361,12 @@ func (b *Bucket) ForEach(fn func(k, v []byte) error) error {
 		return ErrTxClosed
 	}
 	c := b.Cursor()
+	defer c.Close()
 	for k, v := c.First(); k != nil; k, v = c.Next() {
 		if err := fn(k, v); err != nil {
 			return err
 		}
 	}
-	c.Close()
 	return nil
 }
 
@@ -532,6 +535,7 @@ func (b *Bucket) spill() error {
 			panic(fmt.Sprintf("unexpected bucket header flag: %x", flags))
 		}
 		c.node().put([]byte(name), []byte(name), value, 0, bucketLeafFlag)
+		c.Close()
 	}
 
 	// Ignore if there's not a materialized root node.

--- a/cursor.go
+++ b/cursor.go
@@ -48,8 +48,6 @@ func (fs *FreeStack) Get() []elemRef {
 	if l > 0 {
 		s = fs.items[l-1]
 		fs.items = fs.items[:l-1]
-	} else {
-		s = make([]elemRef, 0, 1)
 	}
 	fs.Unlock()
 	return s

--- a/db_test.go
+++ b/db_test.go
@@ -1473,6 +1473,7 @@ func BenchmarkDBBatchManual10x100(b *testing.B) {
 						if err := b.Put(k, []byte("filler")); err != nil {
 							return err
 						}
+						b.Close()
 					}
 					return nil
 				}
@@ -1566,6 +1567,7 @@ func BenchmarkDBTraverse(b *testing.B) {
 			}); err != nil {
 				return err
 			}
+			nodeBucket.Close()
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
We use Bolt to store edges for a graph database. Our database is currently about 5GB. We hit a problem enumerating every edge in the graph. We found Bolt would allocate lots of data in the Go heap: over 4GB, which is enough to kill our process.

When we looked into it the memory was being used by Bolt for Cursors and stacks of elemRefs within Cursors. The cursors were mostly used only briefly, so I tried creating pools of freed Cursors & stacks to see if I could reduce allocations. (I tried using sync.Pool, but rolling my own pools seems more effective)

Here are benchmarks before making the change. BenchmarkDBTraverse is a new benchmark I added for my own situation

```
$ go test -bench . -benchmem
seed: 10802
quick settings: count=5, items=1000, ksize=1024, vsize=1024
00010000000000000000000000000000
PASS
Benchmark_FreelistRelease10K-8         10000        160469 ns/op       82501 B/op          5 allocs/op
Benchmark_FreelistRelease100K-8         1000       1672175 ns/op      805262 B/op          5 allocs/op
Benchmark_FreelistRelease1000K-8         300       4677185 ns/op     8049008 B/op          5 allocs/op
Benchmark_FreelistRelease10000K-8         30      39605709 ns/op    80413040 B/op          5 allocs/op
BenchmarkDBBatchAutomatic-8              500       2918605 ns/op      429473 B/op      10178 allocs/op
BenchmarkDBBatchSingle-8                  10     167128690 ns/op    16855828 B/op      57609 allocs/op
BenchmarkDBBatchManual10x100-8           300       4281479 ns/op      907296 B/op       6006 allocs/op
BenchmarkDBTraverse-8                1000000          1768 ns/op         272 B/op          5 allocs/op
ok      github.com/boltdb/bolt  170.999s
```

Here are benchmarks from after making the change.

```
$ go test -bench . -benchmem
seed: 81596
quick settings: count=5, items=1000, ksize=1024, vsize=1024
00010000000000000000000000000000
PASS
Benchmark_FreelistRelease10K-8         10000        193359 ns/op       82501 B/op          5 allocs/op
Benchmark_FreelistRelease100K-8         1000       1784276 ns/op      805266 B/op          5 allocs/op
Benchmark_FreelistRelease1000K-8         300       4970484 ns/op     8049008 B/op          5 allocs/op
Benchmark_FreelistRelease10000K-8         30      41784659 ns/op    80413040 B/op          5 allocs/op
BenchmarkDBBatchAutomatic-8              500       2741149 ns/op      347806 B/op       8174 allocs/op
BenchmarkDBBatchSingle-8                  10     165493580 ns/op    16899824 B/op      53639 allocs/op
BenchmarkDBBatchManual10x100-8           300       4216260 ns/op      838531 B/op       3986 allocs/op
BenchmarkDBTraverse-8                1000000          1503 ns/op          64 B/op          1 allocs/op
ok      github.com/boltdb/bolt  154.254s
```

Reducing the number of allocations from 5 to 1 in my case is very valuable to me - I should be able to enumerate my database in < 1GB. I expect with only a little more work I can extend the approach to buckets and reduce the allocations to zero per operation.
- Are you interested in taking this change? 
- Is there anything I can do to help you accept it?
