### PR TITLE
Correct broken unaligned load/store in armv5

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -5,3 +5,6 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/bolt_amd64.go
+++ b/bolt_amd64.go
@@ -5,3 +5,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -1,7 +1,28 @@
 package bolt
 
+import "unsafe"
+
 // maxMapSize represents the largest mmap size supported by Bolt.
 const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned bool
+
+func init() {
+	// Simple check to see whether this arch handles unaligned load/stores
+	// correctly.
+
+	// ARM9 and older devices require load/stores to be from/to aligned
+	// addresses. If not, the lower 2 bits are cleared and that address is
+	// read in a jumbled up order.
+
+	// See http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html
+
+	raw := [6]byte{0xfe, 0xef, 0x11, 0x22, 0x22, 0x11}
+	val := *(*uint32)(unsafe.Pointer(uintptr(unsafe.Pointer(&raw)) + 2))
+
+	brokenUnaligned = val != 0x11222211
+}

--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/bolt_ppc64le.go
+++ b/bolt_ppc64le.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/bolt_s390x.go
+++ b/bolt_s390x.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false


### PR DESCRIPTION
## Description

armv5 devices and older (i.e. <= arm9 generation) require addresses that are stored to and loaded from to to be 4-byte aligned.

If this is not the case the lower 2 bits of the address are cleared and the load is performed in an unexpected order, including up to 3 bytes of data located prior to the address.

Inlined buckets are stored after their key in a page and since there is no guarantee that the key will be of a length that is a multiple of 4, it is possible for unaligned load/stores to occur when they are cast back to bucket and page pointer types.

The fix adds a new field to track whether the current architecture exhibits this issue, sets it on module load for ARM architectures, and then on bucket open, if this field is set and the address is unaligned, a byte-by-byte copy of the inlined bucket is performed.

Ref: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html

## Testing

I've tested this fix on actual hardware ([TS-7700](https://www.embeddedarm.com/products/TS-7700)) and run the full suite of tests there (albeit having to reduce some constants due to its limited RAM) - all passing.

## Index out of range

Issues #327 and #430 may well be fixed by this, as the problem usually exhibits itself as an index out of range error.

This occurs because `openBucket()` dereferences a pointer a `bucket` that might not be aligned. Taking a look at the type:

```go
type bucket struct {
	root     pgid   // page id of the bucket's root-level page
	sequence uint64 // monotonically incrementing, used by NextSequence()
}
```

The first field here is a page ID, which is a uint64 (declared as `type pgid uint64`.) When the unaligned access happens it pulls in garbage bytes from up to 3 bytes previous to the address and due to the odd rearrangement of the bytes this number tends to be very large.

Then, when the `pgid` is used to try to reference an address in memory (typically I've found this has occurred in `page()` in `db.go`), `pgid * db.pageSize` exceeds `maxMapSize` and hence the issue manifests as an out of range error:

```go
type DB struct {
	...
	data     *[maxMapSize]byte
	...
}

...

// page retrieves a page reference from the mmap based on the current page size.
func (db *DB) page(id pgid) *page {
	pos := id * pgid(db.pageSize)
	return (*page)(unsafe.Pointer(&db.data[pos]))
}
```

The issue has consistently manifested this way for me prior to the fix.

See this [go playground example](https://play.golang.org/p/JVOtlyxvUY) for a repro + example of the reordering.