### PR TITLE
Fix Go 1.7 pointer reference bug

### DIFF
--- a/node.go
+++ b/node.go
@@ -201,6 +201,11 @@ func (n *node) write(p *page) {
 	}
 	p.count = uint16(len(n.inodes))
 
+	// Stop here if there are no items to write.
+	if p.count == 0 {
+		return
+	}
+
 	// Loop over each item and write it to the page.
 	b := (*[maxAllocSize]byte)(unsafe.Pointer(&p.ptr))[n.pageElementSize()*len(n.inodes):]
 	for i, item := range n.inodes {

--- a/page.go
+++ b/page.go
@@ -62,6 +62,9 @@ func (p *page) leafPageElement(index uint16) *leafPageElement {
 
 // leafPageElements retrieves a list of leaf nodes.
 func (p *page) leafPageElements() []leafPageElement {
+	if p.count == 0 {
+		return nil
+	}
 	return ((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 
@@ -72,6 +75,9 @@ func (p *page) branchPageElement(index uint16) *branchPageElement {
 
 // branchPageElements retrieves a list of branch nodes.
 func (p *page) branchPageElements() []branchPageElement {
+	if p.count == 0 {
+		return nil
+	}
 	return ((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[:]
 }
 


### PR DESCRIPTION
## Overview

This commit fixes a bug where page end-of-header pointers were being converted to byte slices even when the pointer did not point to allocated memory. This occurs with pages that have a `page.count` of zero.

Note: This was not an issue in Go 1.6 but the new Go 1.7 SSA backend handles `nil` checks differently.

See https://github.com/golang/go/issues/16772

/cc @zeebo