### PR TITLE
Lower number of allocation in freelist.reindex()

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -236,7 +236,7 @@ func (f *freelist) reload(p *page) {
 
 // reindex rebuilds the free cache based on available and pending free lists.
 func (f *freelist) reindex() {
-	f.cache = make(map[pgid]bool)
+	f.cache = make(map[pgid]bool, len(f.ids))
 	for _, id := range f.ids {
 		f.cache[id] = true
 	}


### PR DESCRIPTION
Here is a profile taken etcd.
Before:
```
     10924      10924 (flat, cum)  4.99% of Total
         .          .    230:
         .          .    231:// reindex rebuilds the free cache based on available and pending free lists.
         .          .    232:func (f *freelist) reindex() {
         .          .    233:	f.cache = make(map[pgid]bool)
         .          .    234:	for _, id := range f.ids {
     10924      10924    235:		f.cache[id] = true
         .          .    236:	}
         .          .    237:	for _, pendingIDs := range f.pending {
         .          .    238:		for _, pendingID := range pendingIDs {
         .          .    239:			f.cache[pendingID] = true
         .          .    240:		}
```
After:
```
         1          1 (flat, cum) 0.0017% of Total
         .          .    228:	f.reindex()
         .          .    229:
}         .          .    230:
         .          .    231:// reindex rebuilds the free cache based on available and pending free lists.
         .          .    232:func (f *freelist) reindex() {
         1          1    233:	f.cache = make(map[pgid]bool, len(f.ids))
         .          .    234:	for _, id := range f.ids {
         .          .    235:		f.cache[id] = true
         .          .    236:	}
         .          .    237:	for _, pendingIDs := range f.pending {
         .          .    238:		for _, pendingID := range pendingIDs {
```