### PR TITLE
Avoid allocate a hole page, when the node size equals to pageSize

### DIFF
--- a/node.go
+++ b/node.go
@@ -365,7 +365,7 @@ func (n *node) spill() error {
 		}
 
 		// Allocate contiguous space for the node.
-		p, err := tx.allocate((node.size() / tx.db.pageSize) + 1)
+		p, err := tx.allocate((node.size() + tx.db.pageSize - 1) / tx.db.pageSize)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Is there an optimization of allocation pages by design?
