### PR TITLE
Fix Stats.Sub() for Stats.TxN.

### DIFF
--- a/db.go
+++ b/db.go
@@ -952,7 +952,7 @@ func (s *Stats) Sub(other *Stats) Stats {
 	diff.PendingPageN = s.PendingPageN
 	diff.FreeAlloc = s.FreeAlloc
 	diff.FreelistInuse = s.FreelistInuse
-	diff.TxN = other.TxN - s.TxN
+	diff.TxN = s.TxN - other.TxN
 	diff.TxStats = s.TxStats.Sub(&other.TxStats)
 	return diff
 }


### PR DESCRIPTION
## Overview

The subtraction for `TxN` was previously transposed which caused the result to be a negative number. This change alters the order to return the correct (positive) result.

/cc @evandigby