### PR TITLE
Add 'bolter' to the list of projects that use Bolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,5 +854,6 @@ Below is a list of public, open source projects that use Bolt:
 * [GoShort](https://github.com/pankajkhairnar/goShort) - GoShort is a URL shortener written in Golang and BoltDB for persistent key/value storage and for routing it's using high performent HTTPRouter.
 * [torrent](https://github.com/anacrolix/torrent) - Full-featured BitTorrent client package and utilities in Go. BoltDB is a storage backend in development.
 * [gopherpit](https://github.com/gopherpit/gopherpit) - A web service to manage Go remote import paths with custom domains
+* [bolter](https://github.com/hasit/bolter) - Command-line app for viewing BoltDB file in your terminal.
 
 If you are using Bolt in a project please send a pull request to add it to the list.


### PR DESCRIPTION
[bolter](https://github.com/hasit/bolter) is a command-line app for viewing BoltDB file in your terminal using [tablewriter](https://github.com/olekukonko/tablewriter).