### PR TITLE
Fix return statement inside else block at the end of function

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -89,7 +89,7 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 func funlock(db *DB) error {
 	err := unlockFileEx(syscall.Handle(db.lockfile.Fd()), 0, 1, 0, &syscall.Overlapped{})
 	db.lockfile.Close()
-	os.Remove(db.path+lockExt)
+	os.Remove(db.path + lockExt)
 	return err
 }
 

--- a/bucket.go
+++ b/bucket.go
@@ -175,9 +175,8 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 	if bytes.Equal(key, k) {
 		if (flags & bucketLeafFlag) != 0 {
 			return nil, ErrBucketExists
-		} else {
-			return nil, ErrIncompatibleValue
 		}
+		return nil, ErrIncompatibleValue
 	}
 
 	// Create empty, inline bucket.


### PR DESCRIPTION
There was a return statement at the end of a function nested inside an else statement. I removed the else block and unindented the code.

I also ran gofmt on the windows file for a minor semantic change.

Signed-off-by: nick <nicholasjamesrusso@gmail.com>