### PR TITLE
Update bolt_ppc64.go

### DIFF
--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false


### PR DESCRIPTION
Missing variable on ppc64 arch. Not sure if it should be true or false?