### PR TITLE
bucket: correct broken unaligned load/store in ppc64

### DIFF
--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -7,3 +7,6 @@ const maxMapSize = 0xFFFFFFFFFFFF // 256TB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0x7FFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false


### PR DESCRIPTION
similar patch as per ppc64le with cid 97aba55

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>