### PR TITLE
Ensure that keys generated by testing/quick are unique

### DIFF
--- a/quick_test.go
+++ b/quick_test.go
@@ -50,9 +50,17 @@ func (t testdata) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key)
 func (t testdata) Generate(rand *rand.Rand, size int) reflect.Value {
 	n := rand.Intn(qmaxitems-1) + 1
 	items := make(testdata, n)
+	used := make(map[string]bool)
 	for i := 0; i < n; i++ {
 		item := &items[i]
-		item.Key = randByteSlice(rand, 1, qmaxksize)
+		// Ensure that keys are unique by looping until we find one that we have not already used.
+		for {
+			item.Key = randByteSlice(rand, 1, qmaxksize)
+			if !used[string(item.Key)] {
+				used[string(item.Key)] = true
+				break
+			}
+		}
 		item.Value = randByteSlice(rand, 0, qmaxvsize)
 	}
 	return reflect.ValueOf(items)


### PR DESCRIPTION
Quick seed 21691 used to generate duplicate keys, 
which caused some Puts of values to overwrite other values,
causing spurious test failures.

Fixes #629.