### PR TITLE
Prevent bus error caused by reading a corrupted database

### DIFF
--- a/db.go
+++ b/db.go
@@ -481,6 +481,18 @@ func (db *DB) beginTx() (*Tx, error) {
 		return nil, ErrDatabaseNotOpen
 	}
 
+	// Validate the meta pages.
+	if err := db.meta0.validate(); err != nil {
+		db.mmaplock.RUnlock()
+		db.metalock.Unlock()
+		return nil, fmt.Errorf("meta0 error: %s", err)
+	}
+	if err := db.meta1.validate(); err != nil {
+		db.mmaplock.RUnlock()
+		db.metalock.Unlock()
+		return nil, fmt.Errorf("meta1 error: %s", err)
+	}
+
 	// Create a transaction associated with the database.
 	t := &Tx{}
 	t.init(db)


### PR DESCRIPTION
If a read-only database is corrupted and a new read is attempted, the `meta0` and/or `meta1` structs are likewise corrupted and calling `db.meta()` causes a `bus error`.

This patch calls `validate` on these structs before attempting to create a transaction which prevents the `bus error` entirely.

Change-Id: I798dac1a7cf36283fbc64ee63c3e2d80bca54e93