### PR TITLE
provide CommitHook callback, to hook all commits.

### DIFF
--- a/db.go
+++ b/db.go
@@ -94,6 +94,11 @@ type DB struct {
 	// of truncate() and fsync() when growing the data file.
 	AllocSize int
 
+	// The CommitHook function is optional. If set, it will be invoked at
+	// the end of every successful transaction, after all
+	// of the transaction-specific handlers have been invoked.
+	CommitHook func (db *DB)
+	
 	path     string
 	file     *os.File
 	lockfile *os.File // windows only

--- a/tx.go
+++ b/tx.go
@@ -224,6 +224,9 @@ func (tx *Tx) Commit() error {
 	}
 	tx.stats.WriteTime += time.Since(startTime)
 
+	// Save db so we can call the commit hook.
+	db := tx.db
+	
 	// Finalize the transaction.
 	tx.close()
 
@@ -232,6 +235,10 @@ func (tx *Tx) Commit() error {
 		fn()
 	}
 
+	if db.CommitHook != nil {
+		db.CommitHook(db)
+	}
+	
 	return nil
 }
 


### PR DESCRIPTION
Hooking all commits could allow us to implement wrappers.

For example, this would support a wrapper approach to compaction rather than the https://github.com/bigboltdb/bolt fork.