### PR TITLE
avoid data race when reading from read-only tx

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -628,7 +628,7 @@ type TxStats struct {
 	PageAlloc int // total bytes allocated
 
 	// Cursor statistics.
-	CursorCount int // number of cursors created
+	CursorCount int32 // number of cursors created
 
 	// Node statistics
 	NodeCount int // number of node allocations


### PR DESCRIPTION
Concurrently getting buckets and creating cursors on a read-only tx will
trigger a data race on the cursor counter and the bucket subcache. Instead,
use atomics and locks to protect the shared state.