### PR TITLE
Set FillPercent=1.0 in 'bolt compact'.

### DIFF
--- a/cmd/bolt/main.go
+++ b/cmd/bolt/main.go
@@ -1664,6 +1664,9 @@ func (cmd *CompactCommand) compact(dst, src *bolt.DB) error {
 			}
 		}
 
+		// Fill the entire page for best compaction.
+		b.FillPercent = 1.0
+
 		// If there is no value then this is a bucket call.
 		if v == nil {
 			bkt, err := b.CreateBucket(k)


### PR DESCRIPTION
By default, pages are split when they reach half full. For 'bolt compact' we want to fill the entire page for maximum compaction.

I tested on a copy of a production DB of 2.1G. Without setting FillPercent, 'bolt compact' outputs a 1.6G file. After this change, 'bolt compact' outputs a 1.1G file.