### PR TITLE
prevent segfault after mmap failure

### DIFF
--- a/db.go
+++ b/db.go
@@ -280,7 +280,7 @@ func (db *DB) mmap(minsz int) error {
 		if err2 := mmap(db, db.datasz); err2 != nil {
 			panic(fmt.Sprintf("failed to revert db size after failed mmap: %v", err2))
 		}
-		return err
+		return MmapError(err)
 	}
 
 	// Save references to the meta pages.

--- a/db.go
+++ b/db.go
@@ -280,7 +280,7 @@ func (db *DB) mmap(minsz int) error {
 		if err2 := mmap(db, db.datasz); err2 != nil {
 			panic(fmt.Sprintf("failed to revert db size after failed mmap: %v", err2))
 		}
-		return MmapError(err)
+		return MmapError(err.Error())
 	}
 
 	// Save references to the meta pages.

--- a/db.go
+++ b/db.go
@@ -275,6 +275,11 @@ func (db *DB) mmap(minsz int) error {
 
 	// Memory-map the data file as a byte slice.
 	if err := mmap(db, size); err != nil {
+		// mmap failed; the system may have run out of space. Fallback to
+		// mapping the bare minimum needed for the current db size.
+		if err2 := mmap(db, db.datasz); err2 != nil {
+			panic(fmt.Sprintf("failed to revert db size after failed mmap: %v", err2))
+		}
 		return err
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -69,3 +69,8 @@ var (
 	// non-bucket key on an existing bucket key.
 	ErrIncompatibleValue = errors.New("incompatible value")
 )
+
+// MmapError represents an error resulting from a failed mmap call. Typically,
+// this error means that no further database writes will be possible. The most
+// common cause is insufficient disk space.
+type MmapError error

--- a/errors.go
+++ b/errors.go
@@ -73,4 +73,6 @@ var (
 // MmapError represents an error resulting from a failed mmap call. Typically,
 // this error means that no further database writes will be possible. The most
 // common cause is insufficient disk space.
-type MmapError error
+type MmapError string
+
+func (e MmapError) Error() string { return string(e) }


### PR DESCRIPTION
Fixes #706.

This PR causes the db to revert to `mmap(db, db.datasz)` if the call to `mmap(db, minsz)` fails. The original error is still returned, so callers will see `"mmap failure"` returned from `db.Update`. I also wrapped this error in a new type, so that callers can check for it explicitly. This is good to have, since I imagine applications will want to panic instead of continuing to attempt more `db.Update` calls. Another option would be to add a `PanicOnFailedMmap` flag so that bolt will automatically panic under these conditions.

I'm not 100% sure that this code is safe, but I've confirmed that it resolves the segfault bug, and it appears that calls to `db.View` will succeed even after mmap failure.