### PR TITLE
Add kv into "Other Projects Using Bolt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,5 +912,6 @@ Below is a list of public, open source projects that use Bolt:
 * [Ironsmith](https://github.com/timshannon/ironsmith) - A simple, script-driven continuous integration (build - > test -> release) tool, with no external dependencies
 * [BoltHold](https://github.com/timshannon/bolthold) - An embeddable NoSQL store for Go types built on BoltDB
 * [Ponzu CMS](https://ponzu-cms.org) - Headless CMS + automatic JSON API with auto-HTTPS, HTTP/2 Server Push, and flexible server framework.
+* [kv](https://github.com/helinwang/kv) - A Go key/value store service based on BoltDB, access BoltDB from multiple processes.
 
 If you are using Bolt in a project please send a pull request to add it to the list.


### PR DESCRIPTION
I love to use BoltDB, it's easy to use and purely written in Go.
In my use case I need to access the DB from multiple processes. So I created this repo to do exactly that. And it's written in Go, for Go clients (using net/rpc).