### PR TITLE
Add bolt-jna and Keylord projects to 'Other Projects Using Bolt' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,5 +912,7 @@ Below is a list of public, open source projects that use Bolt:
 * [Ironsmith](https://github.com/timshannon/ironsmith) - A simple, script-driven continuous integration (build - > test -> release) tool, with no external dependencies
 * [BoltHold](https://github.com/timshannon/bolthold) - An embeddable NoSQL store for Go types built on BoltDB
 * [Ponzu CMS](https://ponzu-cms.org) - Headless CMS + automatic JSON API with auto-HTTPS, HTTP/2 Server Push, and flexible server framework.
+* [bolt-jna](https://github.com/protonail/bolt-jna) - Java JNA (not JNI) adapter for Bolt DB.
+* [Keylord](https://protonail.com) - Keylord is a desktop GUI client for Redis, Bolt, LevelDB and Memcached key-value databases. It is using bolt-jna adapter to manage Bolt databases.
 
 If you are using Bolt in a project please send a pull request to add it to the list.


### PR DESCRIPTION
I want to add own two projects to 'Other Projects Using Bolt' section.

* [bolt-jna](https://github.com/protonail/bolt-jna) - I think it is the first adapter to Bolt database on Java. Half year ago I couldn't found such adapter and created **bolt-jna** project. It is using cgo for create interface to Bolt compatible with Java JNA adapter.
* [Keylord](https://protonail.com) - Keylord is a desktop GUI client for Redis, Bolt, LevelDB and Memcached key-value databases. It is using bolt-jna adapter inside to manage Bolt databases (create, edit, delete buckets and values).

![Keylord with open Bolt database](https://user-images.githubusercontent.com/27208/29279458-8a4b85ba-8120-11e7-941c-71b3ce252b9e.png)
