### PR TITLE
Add NoSync field to Options

### DIFF
--- a/db.go
+++ b/db.go
@@ -154,6 +154,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	if options == nil {
 		options = DefaultOptions
 	}
+	db.NoSync = options.NoSync
 	db.NoGrowSync = options.NoGrowSync
 	db.MmapFlags = options.MmapFlags
 
@@ -919,6 +920,11 @@ type Options struct {
 	// If initialMmapSize is smaller than the previous database size,
 	// it takes no effect.
 	InitialMmapSize int
+
+	// NoSync sets the initial value of DB.NoSync. Normally this can just be
+	// set directly on the DB itself when returned from Open(), but this option
+	// is useful in APIs which expose Options but not the underlying DB.
+	NoSync bool
 }
 
 // DefaultOptions represent the options used if nil options are passed into Open().


### PR DESCRIPTION
Proposed change to expose `NoSync` in `Options`. Hopefully this is a reasonable change. The justification for this is I use a number of libraries which simply expose the `Options` passed into `Open()` but not the underlying `DB` they create. To enable `NoSync` in these cases, I either have to fork the library or fork bolt.