### PR TITLE
Cleanup file descriptors on failed database initialization

### DIFF
--- a/db.go
+++ b/db.go
@@ -193,10 +193,12 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 
 	// Initialize the database if it doesn't exist.
 	if info, err := db.file.Stat(); err != nil {
+		db.close()
 		return nil, err
 	} else if info.Size() == 0 {
 		// Initialize new files with meta pages.
 		if err := db.init(); err != nil {
+			db.close()
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
Came across this one today on a Unix system...

So when you try to open up a Bolt db that doesn't exist already exist in ReadOnly mode you get an `os.PathError` [when initializing your meta pages](https://github.com/boltdb/bolt/blob/2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8/db.go#L199) and Bolt returns `nil` and the error. Which makes sense; [you've opened (and created) the file with the `O_RDONLY `flag](https://github.com/boltdb/bolt/blob/2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8/db.go#L174) and are now trying to write to it. I don't, personally, think that in ReadOnly mode you _should_ initialize the database.

However the issue is that this happens [_after_ you've acquired your shared lock on the FD](https://github.com/boltdb/bolt/blob/2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8/db.go#L186) and you now have no (direct) means of releasing it (because you've been passed back only `nil`). So if in my program I want to handle this error by creating and initializing a new database in ReadWrite mode I can't because [I hang indefinitely waiting for my exclusive lock](https://github.com/boltdb/bolt/blob/2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8/bolt_unix.go#L30). 
All that this change does is make sure we call close on our partially created database before returning, closing our file so that a subsequent call to Open has a chance of acquiring an exclusive lock on the file.