### PR TITLE
Remove unnecessary if in batch handling

### DIFF
--- a/db.go
+++ b/db.go
@@ -737,9 +737,7 @@ retry:
 
 		// pass success, or bolt internal errors, to all callers
 		for _, c := range b.calls {
-			if c.err != nil {
-				c.err <- err
-			}
+			c.err <- err
 		}
 		break retry
 	}


### PR DESCRIPTION
This is safe, as the only place that creates call values always
explicitly sets err. It's a leftover from an earlier iteration of the
code.