### PR TITLE
Add madvise setting for sequential dbs

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -52,8 +52,8 @@ func mmap(db *DB, sz int) error {
 		return err
 	}
 
-	// Advise the kernel that the mmap is accessed randomly.
-	if err := madvise(b, syscall.MADV_RANDOM); err != nil {
+	// Advise the kernel how the mmap should be accessed.
+	if err := madvise(b, db.Madvise); err != nil {
 		return fmt.Errorf("madvise: %s", err)
 	}
 

--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -62,8 +62,8 @@ func mmap(db *DB, sz int) error {
 		return err
 	}
 
-	// Advise the kernel that the mmap is accessed randomly.
-	if err := unix.Madvise(b, syscall.MADV_RANDOM); err != nil {
+	// Advise the kernel how the mmap should be accessed.
+	if err := unix.Madvise(b, db.Madvise); err != nil {
 		return fmt.Errorf("madvise: %s", err)
 	}
 


### PR DESCRIPTION
Madvise allows advising the kernel how the mmap should be accessed. The default is "random", but if the db is being used sequentially, setting to "normal" has been shown to improve performance on high latency filesystem storage.

Resolves https://github.com/boltdb/bolt/issues/691

Example:
```go
madvise := syscall.MADV_NORMAL
db, err := bolt.Open(path, 0644, &bolt.Options{
	Timeout:    0,
	NoGrowSync: false,
	Madvise: &madvise,
})
```

The reason for the pointer is because an empty value would be "normal" (`0x0`), use options only if set, and keep using "random" by default.
