### PR TITLE
Make boltdb build on ppc

### DIFF
--- a/bolt_ppc.go
+++ b/bolt_ppc.go
@@ -7,3 +7,6 @@ const maxMapSize = 0x7FFFFFFF // 2GB
 
 // maxAllocSize is the size used when creating array pointers.
 const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+var brokenUnaligned = false

--- a/db_test.go
+++ b/db_test.go
@@ -370,8 +370,8 @@ func TestDB_Open_InitialMmapSize(t *testing.T) {
 	path := tempfile()
 	defer os.Remove(path)
 
-	initMmapSize := 1 << 31  // 2GB
-	testWriteSize := 1 << 27 // 134MB
+	initMmapSize := (1 << 31) - 1 // 2GB
+	testWriteSize := 1 << 27      // 134MB
 
 	db, err := bolt.Open(path, 0666, &bolt.Options{InitialMmapSize: initMmapSize})
 	if err != nil {


### PR DESCRIPTION
Trivial PR to fix two problems on ppc:
1. without the `var brokenUnaligned` the build fails with an undefined var
1. the mmap size does not fit into a 32bit register