### PR TITLE
MIPSLE support

### DIFF
--- a/bolt_mipsle.go
+++ b/bolt_mipsle.go
@@ -1,0 +1,11 @@
+package bolt
+
+// maxMapSize represents the largest mmap size supported by Bolt.
+const maxMapSize = 0x3FFFFFFF // 1GB
+
+// maxAllocSize is the size used when creating array pointers.
+const maxAllocSize = 0xFFFFFFF
+
+// Are unaligned load/stores broken on this arch?
+// MIPS needs 32-bit words are aligned to 4 byte boundaries.
+var brokenUnaligned = true

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -53,7 +53,10 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Advise the kernel that the mmap is accessed randomly.
-	if err := madvise(b, syscall.MADV_RANDOM); err != nil {
+	err = madvise(b, syscall.MADV_RANDOM)
+	if err != syscall.ENOSYS {
+		// The syscall is not implemented in kernel but it still works.
+	} else if err != nil {
 		return fmt.Errorf("madvise: %s", err)
 	}
 

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -54,7 +54,7 @@ func mmap(db *DB, sz int) error {
 
 	// Advise the kernel that the mmap is accessed randomly.
 	err = madvise(b, syscall.MADV_RANDOM)
-	if err != syscall.ENOSYS {
+	if err == syscall.ENOSYS {
 		// The syscall is not implemented in kernel but it still works.
 	} else if err != nil {
 		return fmt.Errorf("madvise: %s", err)


### PR DESCRIPTION
BoltDB is written in pure golang, but it doesn't work on MIPSLE architecture. I want to use BoltDB on embed Linux environment (i.e. OpenWRT) running on MIPSLE(MIPS Little Endian)

There are two parts we need to change.

1. variables to define max size and MIPS architecture always needs alignment
2. My current OpenWRT kernel doesn't support madvise syscall. It always returns "function not implemented" error, but it still works fine.

Let me know if you have any questions.
